### PR TITLE
Remove double join on `rails_pulse_requests`

### DIFF
--- a/app/models/rails_pulse/routes/charts/average_response_times.rb
+++ b/app/models/rails_pulse/routes/charts/average_response_times.rb
@@ -16,7 +16,6 @@ module RailsPulse
               .average(:duration)
           else
             @ransack_query.result(distinct: false)
-              .left_joins(:requests)
               .public_send(@group_by, "rails_pulse_requests.occurred_at", series: true, time_zone: "UTC")
               .average("rails_pulse_requests.duration")
           end

--- a/app/models/rails_pulse/routes/tables/index.rb
+++ b/app/models/rails_pulse/routes/tables/index.rb
@@ -21,7 +21,6 @@ module RailsPulse
           status_sql = build_status_sql(thresholds)
 
           @ransack_query.result(distinct: false)
-            .left_joins(:requests)
             .group("rails_pulse_routes.id")
             .select(
               "rails_pulse_routes.*",


### PR DESCRIPTION
Hi 👋
Awesome project! Thank you very much for your work on it. And for open-sourcing it!

I installed it today in one of my projects, and it worked great.
However, after a few hours of usage, there seems to be a bit too much data, and the "/rails_pulse/routes" page no longer loads.

I’m using PostgreSQL 17 and noticed the following long-running query that doesn’t finish, even after several minutes:

<img width="749" height="521" alt="CleanShot 2025-08-18 at 22 41 53" src="https://github.com/user-attachments/assets/597cdef2-aa45-46fa-b609-6982d691ba8f" />

```sql
SELECT
  AVG("rails_pulse_requests"."duration") AS "average_rails_pulse_requests_duration",
  DATE_TRUNC(
    'hour',
    "rails_pulse_requests"."occurred_at" :: timestamptz AT TIME ZONE 'Etc/UTC'
  ) AT TIME ZONE 'Etc/UTC' AS "date_trunc_hour_rails_pulse_requests_occurred_at_timestamptz_at"
FROM
  "rails_pulse_routes"
  LEFT OUTER JOIN "rails_pulse_requests" ON "rails_pulse_requests"."route_id" = "rails_pulse_routes"."id"
  LEFT OUTER JOIN "rails_pulse_requests" "requests_rails_pulse_routes" ON "requests_rails_pulse_routes"."route_id" = "rails_pulse_routes"."id"
WHERE
  (
    "rails_pulse_requests"."duration" >= 0.0
    AND rails_pulse_requests.occurred_at >= '2025-08-17 23:00:00 +0200'
    AND rails_pulse_requests.occurred_at < '2025-08-18 23:59:59 +0200'
  )
  AND ("rails_pulse_requests"."occurred_at" IS NOT NULL)
GROUP BY
  DATE_TRUNC(
    'hour',
    "rails_pulse_requests"."occurred_at" :: timestamptz AT TIME ZONE 'Etc/UTC'
  ) AT TIME ZONE 'Etc/UTC'
```

Current table sizes:
```sql
myapp_development=# select count(*) from rails_pulse_requests;
 count
-------
 38868
(1 row)

myapp_development=# select count(*) from rails_pulse_routes;
 count
-------
  1863
(1 row)
```

The problem seems to be the double join on `rails_pulse_requests`, which produces a Cartesian product per route:

- If a route has 1,000 requests, the first join brings 1,000 rows.
- The second join brings 1,000 rows again.
- Result = 1,000 × 1,000 = 1,000,000 rows per route.

The query appears to come from [this line in the code](https://github.com/railspulse/rails_pulse/blob/main/app/models/rails_pulse/routes/charts/average_response_times.rb#L18-L21)

I removed the explicit join, which fixed the issue for me (though I don’t know the full context of the code, so it might introduce side effects).

---

After that, the next query that hangs is [build here](https://github.com/railspulse/rails_pulse/blob/main/app/models/rails_pulse/routes/tables/index.rb#L23-L35) and looks like this:
```sql
SELECT
  rails_pulse_routes.*,
  COALESCE(AVG(rails_pulse_requests.duration), 0) AS average_response_time_ms,
  COUNT(rails_pulse_requests.id) AS request_count,
  COALESCE(COUNT(rails_pulse_requests.id) / 1468.21, 0) AS requests_per_minute,
  COALESCE(
    SUM(
      CASE
        WHEN rails_pulse_requests.is_error = true THEN 1
        ELSE 0
      END
    ),
    0
  ) AS error_count,
  CASE
    WHEN COUNT(rails_pulse_requests.id) > 0 THEN ROUND(
      (
        COALESCE(
          SUM(
            CASE
              WHEN rails_pulse_requests.is_error = true THEN 1
              ELSE 0
            END
          ),
          0
        ) * 100.0
      ) / COUNT(rails_pulse_requests.id),
      2
    )
    ELSE 0
  END AS error_rate_percentage,
  COALESCE(MAX(rails_pulse_requests.duration), 0) AS max_response_time_ms,
  CASE
    WHEN COALESCE(AVG(rails_pulse_requests.duration), 0) >= 3000 THEN 3
    WHEN COALESCE(AVG(rails_pulse_requests.duration), 0) >= 1500 THEN 2
    WHEN COALESCE(AVG(rails_pulse_requests.duration), 0) >= 500 THEN 1
    ELSE 0
  END AS status_indicator
FROM
  "rails_pulse_routes"
  LEFT OUTER JOIN "rails_pulse_requests" ON "rails_pulse_requests"."route_id" = "rails_pulse_routes"."id"
WHERE
  (
    "rails_pulse_requests"."duration" >= 0.0
    AND rails_pulse_requests.occurred_at >= '2025-08-17 23:00:00 +0200'
    AND rails_pulse_requests.occurred_at < '2025-08-18 23:59:59 +0200'
  )
GROUP BY
  "rails_pulse_routes"."id"
ORDER BY
  COALESCE(AVG(rails_pulse_requests.duration), 0) DESC;
```

This query has the same issue: a double join on `rails_pulse_requests`.

I removed the extra join, and now the routes index page loads again for me.
