### PR TITLE
Remove double join on `rails_pulse_operations`

### DIFF
--- a/app/controllers/rails_pulse/queries_controller.rb
+++ b/app/controllers/rails_pulse/queries_controller.rb
@@ -74,10 +74,7 @@ module RailsPulse
       if show_action?
         @ransack_query.result.select("id", "occurred_at", "duration")
       else
-        # Optimized query: Use INNER JOIN since we only want queries with operations in time range
-        # This dramatically reduces the dataset before aggregation
         @ransack_query.result(distinct: false)
-          .joins("INNER JOIN rails_pulse_operations ON rails_pulse_operations.query_id = rails_pulse_queries.id")
           .where("rails_pulse_operations.occurred_at >= ? AND rails_pulse_operations.occurred_at < ?",
                  Time.at(@table_start_time), Time.at(@table_end_time))
           .group("rails_pulse_queries.id, rails_pulse_queries.normalized_sql, rails_pulse_queries.created_at, rails_pulse_queries.updated_at")

--- a/app/models/rails_pulse/queries/charts/average_query_times.rb
+++ b/app/models/rails_pulse/queries/charts/average_query_times.rb
@@ -16,7 +16,6 @@ module RailsPulse
               .average(:duration)
           else
             @ransack_query.result(distinct: false)
-              .left_joins(:operations)
               .public_send(@group_by, "rails_pulse_operations.occurred_at", series: true, time_zone: "UTC")
               .average("rails_pulse_operations.duration")
           end


### PR DESCRIPTION
Basically the same as in #18, but for "/rails_pulse/queries".
There was a double join on `rails_pulse_operations`, which caused queries to hang for me.

To be honest, it feels odd to just remove the explicit `.joins` calls. I think it would be better to investigate where the implicit joins are coming from and fix the underlying issue.

I opened this PR mainly to showcase the problem. Please feel free to close it when you've found a better solution.

**Query#1:**
```diff
SELECT
  rails_pulse_queries.*,
  COALESCE(AVG(rails_pulse_operations.duration), 0) AS average_query_time_ms,
  COUNT(rails_pulse_operations.id) AS execution_count,
  COALESCE(SUM(rails_pulse_operations.duration), 0) AS total_time_consumed,
  MAX(rails_pulse_operations.occurred_at) AS occurred_at
FROM
  "rails_pulse_queries"
  LEFT OUTER JOIN "rails_pulse_operations" "operations_rails_pulse_queries" ON "operations_rails_pulse_queries"."query_id" = "rails_pulse_queries"."id"
-  INNER JOIN rails_pulse_operations ON rails_pulse_operations.query_id = rails_pulse_queries.id
WHERE
  (
    "rails_pulse_operations"."occurred_at" >= '2025-08-17 21:00:00'
    AND "rails_pulse_operations"."occurred_at" < '2025-08-18 21:59:59'
    AND "rails_pulse_operations"."duration" >= 0.0
  )
  AND (
    rails_pulse_operations.occurred_at >= '2025-08-17 21:00:00'
    AND rails_pulse_operations.occurred_at < '2025-08-18 21:59:59.999999'
  )
GROUP BY
  rails_pulse_queries.id,
  rails_pulse_queries.normalized_sql,
  rails_pulse_queries.created_at,
  rails_pulse_queries.updated_at
ORDER BY
  MAX(rails_pulse_operations.occurred_at) DESC
```

**Query#2**
```diff
SELECT
  AVG("rails_pulse_operations"."duration") AS "average_rails_pulse_operations_duration",
  DATE_TRUNC(
    'hour',
    "rails_pulse_operations"."occurred_at" :: timestamptz AT TIME ZONE 'Etc/UTC'
  ) AT TIME ZONE 'Etc/UTC' AS "date_trunc_hour_rails_pulse_operations_occurred_at_timestamptz_"
FROM
  "rails_pulse_queries"
  LEFT OUTER JOIN "rails_pulse_operations" ON "rails_pulse_operations"."query_id" = "rails_pulse_queries"."id"
-  LEFT OUTER JOIN "rails_pulse_operations" "operations_rails_pulse_queries" ON "operations_rails_pulse_queries"."query_id" = "rails_pulse_queries"."id"
WHERE
  (
    "rails_pulse_operations"."occurred_at" >= '2025-08-17 21:00:00'
    AND "rails_pulse_operations"."occurred_at" < '2025-08-18 21:59:59'
    AND "rails_pulse_operations"."duration" >= 0.0
  )
  AND (
    "rails_pulse_operations"."occurred_at" IS NOT NULL
  )
GROUP BY
  DATE_TRUNC(
    'hour',
    "rails_pulse_operations"."occurred_at" :: timestamptz AT TIME ZONE 'Etc/UTC'
  ) AT TIME ZONE 'Etc/UTC'
```