### PR TITLE
Migration to include normalized sql column size

### DIFF
--- a/db/rails_pulse_migrate/20260420000001_expand_normalized_sql_column.rb
+++ b/db/rails_pulse_migrate/20260420000001_expand_normalized_sql_column.rb
@@ -1,0 +1,28 @@
+class ExpandNormalizedSqlColumn < ActiveRecord::Migration[7.0]
+  def up
+    return unless table_exists?(:rails_pulse_queries)
+
+    adapter = connection.adapter_name.downcase
+
+    # SQLite doesn't enforce string length limits, so no migration needed there.
+    # change_column is also not supported on SQLite.
+    return unless adapter.include?("postgresql") || adapter.include?("mysql")
+
+    column = connection.columns(:rails_pulse_queries).find { |c| c.name == "normalized_sql" }
+    return unless column
+
+    # Only migrate if the column is still a limited string type (not already text)
+    return unless column.type == :string
+
+    change_column :rails_pulse_queries, :normalized_sql, :text, null: false
+  end
+
+  def down
+    return unless table_exists?(:rails_pulse_queries)
+
+    adapter = connection.adapter_name.downcase
+    return unless adapter.include?("postgresql") || adapter.include?("mysql")
+
+    change_column :rails_pulse_queries, :normalized_sql, :string, limit: 1000, null: false
+  end
+end


### PR DESCRIPTION
This PR adds a missing migration to change the size of the `normalized_sql` column for mysql and posgres installations.

Thanks to @ramaboo for the bug report: https://github.com/railspulse/rails_pulse/issues/105