### PR TITLE
Guard against nil Rails.logger during config validation

### DIFF
--- a/lib/rails_pulse/configuration.rb
+++ b/lib/rails_pulse/configuration.rb
@@ -204,7 +204,13 @@ module RailsPulse
 
     def validate_authentication_settings!
       if @authentication_enabled && @authentication_method.nil?
-        RailsPulse.logger.warn "Authentication is enabled but no authentication method is configured. This will deny all access."
+        warning = "Authentication is enabled but no authentication method is configured. This will deny all access."
+        # Use Rails.logger if available, otherwise fall back to puts (for asset precompilation)
+        if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
+          RailsPulse.logger.warn warning
+        else
+          puts "RailsPulse: #{warning}"
+        end
       end
 
       if @authentication_method && ![ Proc, Symbol, String ].include?(@authentication_method.class)

--- a/test/lib/rails_pulse/configuration_test.rb
+++ b/test/lib/rails_pulse/configuration_test.rb
@@ -382,5 +382,25 @@ module RailsPulse
 
       assert_match(/must be a positive number/i, error.message)
     end
+
+    test "validate_authentication_settings! tolerates nil Rails.logger" do
+      # Reproduces the asset precompilation crash: validation runs while
+      # Rails.logger is still nil (e.g. RAILS_ENV=production rake task before
+      # Rails::Application#initialize!).
+      config = Configuration.new
+      config.instance_variable_set(:@authentication_enabled, true)
+      config.instance_variable_set(:@authentication_method, nil)
+
+      original_logger = Rails.logger
+      Rails.logger = nil
+      RailsPulse.instance_variable_set(:@logger, nil)
+
+      begin
+        assert_nothing_raised { config.validate_configuration! }
+      ensure
+        Rails.logger = original_logger
+        RailsPulse.instance_variable_set(:@logger, nil)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

On v0.3.0, `RAILS_ENV=production bin/rails assets:precompile` crashes with `NoMethodError: undefined method 'formatter' for nil` when no authentication_method is configured. 

PR #11 originally added a nil guard for this exact case (with the comment `# (for asset precompilation`)). PR #100 dropped it as redundant after removing the eager `validate_configuration!` call. PR #109 brought back the eager call without restoring the guard, turning #98's warning into a load-time crash.
This restores the guard. Behaviour is unchanged when `Rails.logger` is set; when it isn't, the warning falls back to puts like before.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)
- [ ] Documentation update
- [x] Test improvements
- [ ] Build/CI improvements

## Changes Made

- Restore Rails.logger nil guard in validate_authentication_settings!.
- Add regression test in test/lib/rails_pulse/configuration_test.rb that reproduces the production stack trace.

### Test Results

- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Manual testing completed
- [ ] Tested across multiple databases (SQLite, PostgreSQL, MySQL)
- [ ] Tested across multiple Rails versions (7.2, 8.0, 8.1)

## Breaking Changes

- [ ] No breaking changes
- [ ] Breaking changes documented below

## Screenshots

N/A

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Comments added for complex logic
- [ ] Documentation updated (if applicable)
- [x] No new warnings or errors introduced
- [x] Tests added/updated and passing
- [ ] Changes work with all supported databases
- [ ] Changes work with all supported Rails versions
- [ ] Asset changes compiled and included (if applicable)

## Additional Notes

Locally tested on Rails 8.1.3 + SQLite only; the patched code path is DB-agnostic and depends only on `Rails.respond_to?(:logger) / Rails.logger`

Reproduction:
```bash
rails new app --minimal --skip-bundle --database=sqlite3
cd app
echo 'gem "rails_pulse"' >> Gemfile
bundle install
RAILS_ENV=production SECRET_KEY_BASE_DUMMY=1 bin/rails assets:precompile
```

Crashes on 0.3.0, passes with this patch.

Refs #11, #98, #100, #109.
