### PR TITLE
Fix broken schema template and update docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,20 +2,22 @@
 
 ## Database Migrations
 
-Rails Pulse has a two-path migration architecture. Always keep both paths in mind when making schema changes.
+Rails Pulse has a three-path migration architecture. Always keep all three paths in mind when making schema changes.
 
 ### How it works
 
 - **`db/rails_pulse_schema.rb`** is the single source of truth for the complete schema. It is used only for fresh installations — it checks `table_exists?` before creating each table and will never modify existing tables.
+- **`lib/generators/rails_pulse/templates/db/rails_pulse_schema.rb`** is the generator template that gets copied into users' apps when they run `rails generate rails_pulse:install`. It must always be kept identical to `db/rails_pulse_schema.rb`.
 - **`db/rails_pulse_migrate/`** contains incremental migrations for new features. These are copied into users' apps by the upgrade generator (`rails generate rails_pulse:upgrade`).
-- The install generator (`rails generate rails_pulse:install`) creates a single migration that loads and executes the schema file.
+- The install generator (`rails generate rails_pulse:install`) copies the template schema into the user's app, then creates a migration that loads and executes it.
 
 ### When adding a new column or table
 
-You must update **both**:
+You must update **all three**:
 
-1. **`db/rails_pulse_schema.rb`** — add the column/table for fresh installs
-2. **`db/rails_pulse_migrate/TIMESTAMP_description.rb`** — add an incremental migration with `column_exists?`/`table_exists?` guards for existing installs
+1. **`db/rails_pulse_schema.rb`** — add the column/table for fresh installs (source of truth)
+2. **`lib/generators/rails_pulse/templates/db/rails_pulse_schema.rb`** — keep in sync with the source of truth so the install generator produces correct output
+3. **`db/rails_pulse_migrate/TIMESTAMP_description.rb`** — add an incremental migration with `column_exists?`/`table_exists?` guards for existing installs
 
 Example incremental migration pattern:
 ```ruby

--- a/docs/database_setup.md
+++ b/docs/database_setup.md
@@ -245,9 +245,10 @@ When adding a new feature that requires a database column:
    end
    ```
 
-2. Update the schema file to include the column (for new installations):
+ 2. Update **both** schema files to include the column (for new installations):
    ```ruby
-   # db/rails_pulse_schema.rb
+   # db/rails_pulse_schema.rb  (source of truth)
+   # lib/generators/rails_pulse/templates/db/rails_pulse_schema.rb  (generator template — must match!)
    unless connection.table_exists?(:rails_pulse_jobs)
      connection.create_table :rails_pulse_jobs do |t|
        # ... existing columns ...
@@ -255,6 +256,11 @@ When adding a new feature that requires a database column:
      end
    end
    ```
+
+   > **Important**: The generator template at `lib/generators/rails_pulse/templates/db/rails_pulse_schema.rb`
+   > is what gets copied into users' apps when they run `rails generate rails_pulse:install`. It must be
+   > kept in sync with `db/rails_pulse_schema.rb` — failing to update it means fresh installs will be
+   > missing the new column even though the source of truth is correct.
 
 3. Users run the upgrade generator to get the migration:
    ```bash

--- a/lib/generators/rails_pulse/templates/db/rails_pulse_schema.rb
+++ b/lib/generators/rails_pulse/templates/db/rails_pulse_schema.rb
@@ -40,8 +40,8 @@ RailsPulse::Schema ||= lambda do |connection|
 
   unless connection.table_exists?(:rails_pulse_queries)
     connection.create_table :rails_pulse_queries do |t|
-      t.string :hashed_sql, limit: 32, null: false, comment: "MD5 hash of normalized SQL for indexing"
-      t.text :normalized_sql, null: false, comment: "Normalized SQL query string (e.g., SELECT * FROM users WHERE id = ?)"
+      t.string :hashed_sql, limit: 32, null: false, comment: "MD5 hash of normalized SQL for fast lookups and uniqueness"
+      t.text :normalized_sql, null: false, comment: "Full normalized SQL query string (e.g., SELECT * FROM users WHERE id = ?)"
       t.datetime :analyzed_at, comment: "When query analysis was last performed"
       t.text :explain_plan, comment: "EXPLAIN output from actual SQL execution"
       t.text :issues, comment: "JSON array of detected performance issues"
@@ -68,6 +68,7 @@ RailsPulse::Schema ||= lambda do |connection|
       t.string :controller_action, comment: "Controller and action handling the request (e.g., PostsController#show)"
       t.timestamp :occurred_at, null: false, comment: "When the request started"
       t.text :tags, comment: "JSON array of tags for filtering and categorization"
+      t.integer :response_size_bytes, comment: "HTTP response body size in bytes"
       t.timestamps
     end
 
@@ -131,6 +132,10 @@ RailsPulse::Schema ||= lambda do |connection|
       t.string :codebase_location, comment: "File and line number (e.g., app/models/user.rb:25)"
       t.float :start_time, null: false, default: 0.0, comment: "Operation start time in milliseconds"
       t.timestamp :occurred_at, null: false, comment: "When the request started"
+      t.integer :row_count, comment: "Number of rows returned (SQL operations, Rails 7.1+)"
+      t.boolean :cache_hit, comment: "Whether a cache_read operation hit the cache"
+      t.text :repeated_query_group, comment: "Normalized SQL key identifying an N+1 group"
+      t.integer :repetition_count, comment: "Number of times this query pattern repeated in the request"
       t.timestamps
     end
 
@@ -154,7 +159,7 @@ RailsPulse::Schema ||= lambda do |connection|
       t.string :period_type, null: false, comment: "Aggregation period type: hour, day, week, month"
 
       # Polymorphic association to handle both routes and queries
-      t.references :summarizable, polymorphic: true, null: false, index: false, comment: "Link to Route or Query"
+      t.references :summarizable, polymorphic: true, null: false, index: true, comment: "Link to Route or Query"
       # This creates summarizable_type (e.g., 'RailsPulse::Route', 'RailsPulse::Query')
       # and summarizable_id (route_id or query_id)
 


### PR DESCRIPTION
## Summary

This adds missing fields to the `lib/generators/rails_pulse/templates/db/rails_pulse_schema.rb` template and updates documentation to hopefully prevent it happening again.
