### PR TITLE
Fix rails logger

### DIFF
--- a/lib/rails_pulse.rb
+++ b/lib/rails_pulse.rb
@@ -16,7 +16,11 @@ module RailsPulse
     end
 
     def logger
-      @logger ||= ActiveSupport::TaggedLogging.new(Rails.logger).tagged("RailsPulse")
+      if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
+        @logger ||= ActiveSupport::TaggedLogging.new(Rails.logger).tagged("RailsPulse")
+      else
+        Logger.new($stdout)
+      end
     end
 
     def clear_metric_cache!

--- a/test/lib/rails_pulse/configuration_test.rb
+++ b/test/lib/rails_pulse/configuration_test.rb
@@ -382,5 +382,22 @@ module RailsPulse
 
       assert_match(/must be a positive number/i, error.message)
     end
+
+    test "validate_authentication_settings! tolerates nil Rails.logger" do
+      config = Configuration.new
+      config.instance_variable_set(:@authentication_enabled, true)
+      config.instance_variable_set(:@authentication_method, nil)
+
+      original_logger = Rails.logger
+      Rails.logger = nil
+      RailsPulse.instance_variable_set(:@logger, nil)
+
+      begin
+        assert_nothing_raised { config.validate_configuration! }
+      ensure
+        Rails.logger = original_logger
+        RailsPulse.instance_variable_set(:@logger, nil)
+      end
+    end
   end
 end

--- a/test/rails_pulse_test.rb
+++ b/test/rails_pulse_test.rb
@@ -4,4 +4,38 @@ class RailsPulseTest < ActiveSupport::TestCase
   test "it has a version number" do
     assert RailsPulse::VERSION
   end
+
+  test "logger falls back to stdout when Rails.logger is nil" do
+    original = Rails.logger
+    Rails.logger = nil
+    RailsPulse.instance_variable_set(:@logger, nil)
+
+    logger = RailsPulse.logger
+    assert_respond_to logger, :warn
+    assert_respond_to logger, :info
+  ensure
+    Rails.logger = original
+    RailsPulse.instance_variable_set(:@logger, nil)
+  end
+
+  test "logger is not memoized when falling back so real logger is picked up later" do
+    original = Rails.logger
+    Rails.logger = nil
+    RailsPulse.instance_variable_set(:@logger, nil)
+
+    # First call with nil Rails.logger returns a fallback logger
+    fallback_logger = RailsPulse.logger
+
+    # Simulate Rails finishing boot and providing a real logger
+    Rails.logger = original
+
+    # Next call should pick up the real logger, not the fallback
+    real_logger = RailsPulse.logger
+    assert_respond_to real_logger, :tagged
+    assert_respond_to real_logger, :formatter
+    assert_not_equal fallback_logger, real_logger
+  ensure
+    Rails.logger = original
+    RailsPulse.instance_variable_set(:@logger, nil)
+  end
 end

--- a/test/rails_pulse_test.rb
+++ b/test/rails_pulse_test.rb
@@ -11,6 +11,7 @@ class RailsPulseTest < ActiveSupport::TestCase
     RailsPulse.instance_variable_set(:@logger, nil)
 
     logger = RailsPulse.logger
+
     assert_respond_to logger, :warn
     assert_respond_to logger, :info
   ensure
@@ -31,6 +32,7 @@ class RailsPulseTest < ActiveSupport::TestCase
 
     # Next call should pick up the real logger, not the fallback
     real_logger = RailsPulse.logger
+
     assert_respond_to real_logger, :tagged
     assert_respond_to real_logger, :formatter
     assert_not_equal fallback_logger, real_logger


### PR DESCRIPTION
## Summary
Fixes a `NoMethodError: undefined method 'formatter' for nil` crash that occurs during `RAILS_ENV=production bin/rails assets:precompile` when `Rails.logger` has not yet been initialized.

Replaces the call-site guard from PR #123 with a centralized fix in `RailsPulse.logger` so all 50+ call sites across the codebase are protected.

## Root cause

`RailsPulse.logger` wrapped `Rails.logger` unconditionally. During asset precompilation, Rails loads the app but `Rails.logger` is still `nil`, causing `ActiveSupport::TaggedLogging.new(nil)` to delegate `.formatter` to `nil`.

## Fix

- `RailsPulse.logger` now checks `Rails.logger` availability before wrapping it
- Falls back to `Logger.new($stdout)` when `Rails.logger` is absent
- Fallback is intentionally **not memoized**, so the real logger is picked up
  once Rails finishes booting

## Tests
- `test/rails_pulse_test.rb`: unit tests for fallback behavior and non-memoization
- `test/lib/rails_pulse/configuration_test.rb`: integration test reproducing the
  exact asset precompilation crash

Closes #123 (supersedes with a more robust approach)