### PR TITLE
Run upgrade generator automatically after install

### DIFF
--- a/lib/generators/rails_pulse/install_generator.rb
+++ b/lib/generators/rails_pulse/install_generator.rb
@@ -33,6 +33,10 @@ module RailsPulse
         end
       end
 
+      def run_upgrade
+        generate "rails_pulse:upgrade", "--database=#{options[:database]}"
+      end
+
       def display_post_install_message
         if separate_database?
           display_separate_database_message


### PR DESCRIPTION
The install generator now automatically runs the upgrade generator at the end of setup. This ensures new users get all migrations copied in one step without needing to manually run `rails generate rails_pulse:upgrade` separately.