### PR TITLE
Add host tracking to routes via normalized hosts table

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,41 @@ Authentication guide: [railspulse.com/documentation/authentication](https://rail
 ## Features
 
 - **Request monitoring** — every request is timed and stored with its route, status, SQL count, and duration. Slow requests are flagged automatically based on thresholds you control.
+- **Host tracking** — routes are scoped per-host, so multi-domain apps can see performance broken down by hostname. Hosts are created automatically as new requests arrive.
 - **Query analysis** — captures the queries behind each request, detects N+1 patterns, and tracks normalized SQL across requests so you can see which queries are hurting you in production, not just in development.
 - **Job tracking** — monitors background job duration, queue wait time, and failure rates. Works with any Active Job adapter.
 - **System health bar** — at-a-glance dashboard summary showing healthy, slow, and critical counts across your routes, queries, jobs, and storage. Lets you see the overall state of your app before drilling into specifics.
 - **No data leaves your app** — everything is stored in your own database. No third-party cloud, no SaaS subscription, no outbound connections.
 - **Low overhead** — tracking is async and uses a thread-local flag to skip recording Rails Pulse's own internal requests.
+
+## Upgrading
+
+After updating the gem, run the upgrade generator to pick up new migrations:
+
+```bash
+rails generate rails_pulse:upgrade
+rails db:migrate
+```
+
+### Backfilling hosts
+
+If you upgraded from a version that didn't track hosts, existing routes will have no host assigned (`host_id = NULL`). New requests will automatically create and assign hosts going forward.
+
+To retroactively assign orphaned routes to a host:
+
+```bash
+rails rails_pulse:backfill_hosts[example.com]
+```
+
+This will:
+- Create the host record if it doesn't exist
+- Assign all orphaned routes to that host
+- Merge duplicates automatically — if a route with the same method+path already exists for that host, requests and summaries are moved to the existing route and the orphan is removed
+
+For multi-domain apps, there's no way to determine which orphaned routes belonged to which host from historical data alone. You have two options:
+
+1. **Let it backfill naturally** — skip the rake task entirely. New requests will create hosts and new route records automatically. Old orphaned routes will remain visible in the Routes view with no host.
+2. **Assign to your primary host** — run the task with your main domain. Routes from other hosts will sort themselves out as new traffic arrives.
 
 ## Contributing
 

--- a/app/controllers/rails_pulse/hosts_controller.rb
+++ b/app/controllers/rails_pulse/hosts_controller.rb
@@ -1,0 +1,30 @@
+module RailsPulse
+  class HostsController < ApplicationController
+    def index
+      @hosts = Host
+        .left_joins(routes: :requests)
+        .group("rails_pulse_hosts.id")
+        .select(
+          "rails_pulse_hosts.*",
+          "COUNT(DISTINCT rails_pulse_routes.id) as routes_count",
+          "COUNT(rails_pulse_requests.id) as requests_count",
+          "AVG(rails_pulse_requests.duration) as avg_duration"
+        )
+        .order("requests_count DESC")
+    end
+
+    def show
+      @host = Host.find(params[:id])
+      @routes = @host.routes
+        .left_joins(:requests)
+        .group("rails_pulse_routes.id")
+        .select(
+          "rails_pulse_routes.*",
+          "COUNT(rails_pulse_requests.id) as requests_count",
+          "AVG(rails_pulse_requests.duration) as avg_duration",
+          "SUM(CASE WHEN rails_pulse_requests.is_error THEN 1 ELSE 0 END) as error_count"
+        )
+        .order("requests_count DESC")
+    end
+  end
+end

--- a/app/controllers/rails_pulse/requests_controller.rb
+++ b/app/controllers/rails_pulse/requests_controller.rb
@@ -99,7 +99,7 @@ module RailsPulse
     # This differs from Routes/Queries which use Tables::Index for aggregation
     # Individual records allow displaying per-request details (tags, occurred_at, etc.)
     def build_table_results
-      base_query = apply_tag_filters(@ransack_query.result.includes(:route))
+      base_query = apply_tag_filters(@ransack_query.result.includes(route: :host))
 
       # If filtering or sorting by route_path, we need to join the routes table
       needs_join = @ransack_query.sorts.any? { |sort| sort.name == "route_path" } ||

--- a/app/models/rails_pulse/dashboard/needs_attention.rb
+++ b/app/models/rails_pulse/dashboard/needs_attention.rb
@@ -51,11 +51,13 @@ module RailsPulse
         route_data = RailsPulse::Summary
           .with_tag_filters(@disabled_tags, @show_non_tagged)
           .joins("INNER JOIN rails_pulse_routes ON rails_pulse_routes.id = rails_pulse_summaries.summarizable_id")
+          .joins("LEFT JOIN rails_pulse_hosts ON rails_pulse_hosts.id = rails_pulse_routes.host_id")
           .where(summarizable_type: "RailsPulse::Route", period_start: start..finish)
-          .group("rails_pulse_summaries.summarizable_id, rails_pulse_routes.path")
+          .group("rails_pulse_summaries.summarizable_id, rails_pulse_routes.path, rails_pulse_hosts.name")
           .select(
             "rails_pulse_summaries.summarizable_id as route_id",
             "rails_pulse_routes.path",
+            "rails_pulse_hosts.name as host_name",
             "SUM(rails_pulse_summaries.p95_duration * rails_pulse_summaries.count) / NULLIF(SUM(rails_pulse_summaries.count), 0) as p95_duration",
             "SUM(rails_pulse_summaries.count) as total_count",
             "SUM(rails_pulse_summaries.error_count) as total_errors"
@@ -73,7 +75,7 @@ module RailsPulse
 
           items << {
             type:       "ROUTE",
-            name:       record.path,
+            name:       "#{record.host_name}#{record.path}",
             reason:     reason,
             metric:     metric,
             metric_sub: metric_sub,

--- a/app/models/rails_pulse/host.rb
+++ b/app/models/rails_pulse/host.rb
@@ -1,0 +1,13 @@
+module RailsPulse
+  class Host < RailsPulse::ApplicationRecord
+    self.table_name = "rails_pulse_hosts"
+
+    has_many :routes, class_name: "RailsPulse::Route", foreign_key: "host_id", dependent: :restrict_with_exception
+
+    validates :name, presence: true, uniqueness: true
+
+    def to_s
+      name
+    end
+  end
+end

--- a/app/models/rails_pulse/route.rb
+++ b/app/models/rails_pulse/route.rb
@@ -5,23 +5,30 @@ module RailsPulse
     self.table_name = "rails_pulse_routes"
 
     # Associations
+    belongs_to :host, class_name: "RailsPulse::Host", optional: true
     has_many :requests, class_name: "RailsPulse::Request", foreign_key: "route_id", dependent: :restrict_with_exception
     has_many :summaries, as: :summarizable, class_name: "RailsPulse::Summary", dependent: :destroy
 
     # Validations
     validates :method, presence: true
-    validates :path, presence: true, uniqueness: { scope: :method, message: "and method combination must be unique" }
+    validates :path, presence: true, uniqueness: { scope: [:method, :host_id], message: "method and host combination must be unique" }
 
     # Scopes (optional, for convenience)
     scope :by_method_and_path, ->(method, path) { where(method: method, path: path).first_or_create }
 
     def self.ransackable_attributes(auth_object = nil)
-      %w[path average_response_time_ms max_response_time_ms request_count requests_per_minute occurred_at requests_occurred_at error_count error_rate_percentage status_indicator]
+      %w[path host_id average_response_time_ms max_response_time_ms request_count requests_per_minute occurred_at requests_occurred_at error_count error_rate_percentage status_indicator]
     end
 
     def self.ransackable_associations(auth_object = nil)
-      %w[requests]
+      %w[requests host]
     end
+
+    def host_name
+      host&.name
+    end
+
+
 
     ransacker :average_response_time_ms do
       Arel.sql("COALESCE(AVG(rails_pulse_requests.duration), 0)")
@@ -60,7 +67,7 @@ module RailsPulse
     end
 
     def to_breadcrumb
-      "#{method.upcase} #{path}".truncate(60)
+      "#{host_name}#{path} #{method.upcase}".truncate(60)
     end
 
     def self.average_response_time
@@ -68,7 +75,7 @@ module RailsPulse
     end
 
     def path_and_method
-      "#{path} #{method}"
+      "#{host_name}#{path} #{method}"
     end
   end
 end

--- a/app/models/rails_pulse/routes/tables/index.rb
+++ b/app/models/rails_pulse/routes/tables/index.rb
@@ -41,12 +41,14 @@ module RailsPulse
 
           # Apply grouping and aggregation
           grouped_query = base_query
+            .joins("LEFT JOIN rails_pulse_hosts ON rails_pulse_hosts.id = rails_pulse_routes.host_id")
             .group(
               "rails_pulse_summaries.summarizable_id",
               "rails_pulse_summaries.summarizable_type",
               "rails_pulse_routes.id",
               "rails_pulse_routes.path",
               "rails_pulse_routes.method",
+              "rails_pulse_hosts.name",
               "rails_pulse_routes.tags"
             )
             .select(
@@ -55,6 +57,7 @@ module RailsPulse
               "rails_pulse_routes.id as route_id",
               "rails_pulse_routes.path",
               "rails_pulse_routes.method as route_method",
+              "rails_pulse_hosts.name as host_name",
               "rails_pulse_routes.tags",
               "AVG(rails_pulse_summaries.avg_duration) as avg_duration",
               "MAX(rails_pulse_summaries.max_duration) as max_duration",

--- a/app/views/layouts/rails_pulse/_menu_items.html.erb
+++ b/app/views/layouts/rails_pulse/_menu_items.html.erb
@@ -8,6 +8,11 @@
   <span class="overflow-ellipsis">Routes</span>
 <% end %>
 
+<%= link_to hosts_path, class: 'btn sidebar-menu__button' do %>
+  <%= rails_pulse_icon 'globe', width: '16' %>
+  <span class="overflow-ellipsis">Hosts</span>
+<% end %>
+
 <%= link_to queries_path, class: 'btn sidebar-menu__button' do %>
   <%= rails_pulse_icon 'database', width: '16' %>
   <span class="overflow-ellipsis">Queries</span>

--- a/app/views/rails_pulse/hosts/index.html.erb
+++ b/app/views/rails_pulse/hosts/index.html.erb
@@ -1,0 +1,24 @@
+<%= render "rails_pulse/components/page_header" %>
+
+<%= render 'rails_pulse/components/panel', title: 'Hosts', card_classes: 'b-full' do %>
+  <table class="table table-fixed mbs-4">
+    <thead>
+      <tr>
+        <th class="w-auto">Host</th>
+        <th class="w-24">Routes</th>
+        <th class="w-24">Requests</th>
+        <th class="w-32">Avg Response</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @hosts.each do |host| %>
+        <tr>
+          <td class="truncate-cell"><%= link_to host.name, host_path(host) %></td>
+          <td class="whitespace-nowrap"><%= number_with_delimiter host.routes_count %></td>
+          <td class="whitespace-nowrap"><%= number_with_delimiter host.requests_count %></td>
+          <td class="whitespace-nowrap"><%= host.avg_duration.to_f.round(1) %> ms</td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/rails_pulse/hosts/show.html.erb
+++ b/app/views/rails_pulse/hosts/show.html.erb
@@ -1,0 +1,26 @@
+<%= render "rails_pulse/components/page_header" %>
+
+<%= render 'rails_pulse/components/panel', title: @host.name, card_classes: 'b-full' do %>
+  <table class="table table-fixed mbs-4">
+    <thead>
+      <tr>
+        <th class="w-auto">Route</th>
+        <th class="w-20">Method</th>
+        <th class="w-24">Requests</th>
+        <th class="w-32">Avg Response</th>
+        <th class="w-24">Errors</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @routes.each do |route| %>
+        <tr>
+          <td class="truncate-cell"><%= link_to route.path, route_path(route) %></td>
+          <td class="whitespace-nowrap"><%= route.method %></td>
+          <td class="whitespace-nowrap"><%= number_with_delimiter route.requests_count %></td>
+          <td class="whitespace-nowrap"><%= route.avg_duration.to_f.round(1) %> ms</td>
+          <td class="whitespace-nowrap"><%= number_with_delimiter route.error_count %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/rails_pulse/requests/_table.html.erb
+++ b/app/views/rails_pulse/requests/_table.html.erb
@@ -22,7 +22,7 @@
       %>
       <tr>
         <td class="truncate-cell">
-          <%= link_to "#{request.route.path} #{request.route.method}", route_path(request.route) %>
+          <%= link_to "#{request.route.host_name}#{request.route.path} #{request.route.method}", route_path(request.route) %>
         </td>
         <td class="whitespace-nowrap">
           <%= link_to human_readable_occurred_at(request.occurred_at), request_path(request) %>

--- a/app/views/rails_pulse/requests/show.html.erb
+++ b/app/views/rails_pulse/requests/show.html.erb
@@ -6,6 +6,8 @@
       <dl class="descriptive-list mbs-4">
         <dt>Route</dt>
         <dd><%= link_to @request.route.path_and_method, route_path(@request.route) %></dd>
+        <dt>Host</dt>
+        <dd><%= @request.route.host_name %></dd>
         <dt>Timestamp</dt>
         <dd><%= human_readable_occurred_at(@request.occurred_at) %></dd>
         <dt>Duration</dt>

--- a/app/views/rails_pulse/routes/_table.html.erb
+++ b/app/views/rails_pulse/routes/_table.html.erb
@@ -12,7 +12,7 @@
   <tbody>
     <% @table_data.each do |summary| %>
       <tr>
-        <td class="truncate-cell"><%= link_to "#{summary.path} #{summary.route_method}", route_path(summary.route_id) %></td>
+        <td class="truncate-cell"><%= link_to "#{summary.host_name}#{summary.path} #{summary.route_method}", route_path(summary.route_id) %></td>
         <td class="whitespace-nowrap"><%= summary.p95_duration.to_i %> ms</td>
         <td class="whitespace-nowrap"><%= summary.p99_duration.to_i %> ms</td>
         <td class="whitespace-nowrap"><%= number_with_delimiter summary.count %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ RailsPulse::Engine.routes.draw do
 
   resources :routes, only: %i[index show]
   resources :requests, only: %i[index show]
+  resources :hosts, only: %i[index show]
   resources :queries, only: %i[index show] do
     member do
       post :reanalyze

--- a/db/rails_pulse_migrate/20260505000001_add_host_to_rails_pulse_routes.rb
+++ b/db/rails_pulse_migrate/20260505000001_add_host_to_rails_pulse_routes.rb
@@ -1,0 +1,36 @@
+class AddHostToRailsPulseRoutes < ActiveRecord::Migration[7.2]
+  def up
+    create_table :rails_pulse_hosts do |t|
+      t.string :name, null: false, comment: "Hostname (e.g., example.com)"
+      t.timestamps
+    end
+
+    add_index :rails_pulse_hosts, :name, unique: true, name: "index_rails_pulse_hosts_on_name"
+
+    add_reference :rails_pulse_routes, :host, foreign_key: { to_table: :rails_pulse_hosts }, comment: "Link to the host"
+
+    # Replace the old unique index with one that includes host_id
+    remove_index :rails_pulse_routes, name: "index_rails_pulse_routes_on_method_and_path"
+    add_index :rails_pulse_routes, [:method, :path, :host_id], unique: true, name: "index_rails_pulse_routes_on_method_path_and_host"
+
+    # Existing routes will have host_id = NULL. This is intentional — the host
+    # wasn't tracked before this migration. New requests will auto-create hosts.
+    # To backfill existing routes, run: rails rails_pulse:backfill_hosts[example.com]
+  end
+
+  def down
+    remove_index :rails_pulse_routes, name: "index_rails_pulse_routes_on_method_path_and_host"
+
+    # Deduplicate routes that share method+path (keep lowest id)
+    execute <<~SQL
+      DELETE FROM rails_pulse_routes
+      WHERE id NOT IN (
+        SELECT MIN(id) FROM rails_pulse_routes GROUP BY method, path
+      )
+    SQL
+
+    add_index :rails_pulse_routes, [:method, :path], unique: true, name: "index_rails_pulse_routes_on_method_and_path"
+    remove_reference :rails_pulse_routes, :host, foreign_key: { to_table: :rails_pulse_hosts }
+    drop_table :rails_pulse_hosts
+  end
+end

--- a/db/rails_pulse_schema.rb
+++ b/db/rails_pulse_schema.rb
@@ -26,15 +26,25 @@ RailsPulse::Schema ||= lambda do |connection|
     return
   end
 
+  unless connection.table_exists?(:rails_pulse_hosts)
+    connection.create_table :rails_pulse_hosts do |t|
+      t.string :name, null: false, comment: "Hostname (e.g., example.com)"
+      t.timestamps
+    end
+
+    connection.add_index :rails_pulse_hosts, :name, unique: true, name: "index_rails_pulse_hosts_on_name"
+  end
+
   unless connection.table_exists?(:rails_pulse_routes)
     connection.create_table :rails_pulse_routes do |t|
       t.string :method, null: false, comment: "HTTP method (e.g., GET, POST)"
       t.string :path, null: false, comment: "Request path (e.g., /posts/index)"
+      t.references :host, foreign_key: { to_table: :rails_pulse_hosts }, comment: "Link to the host"
       t.text :tags, comment: "JSON array of tags for filtering and categorization"
       t.timestamps
     end
 
-    connection.add_index :rails_pulse_routes, [ :method, :path ], unique: true, name: "index_rails_pulse_routes_on_method_and_path"
+    connection.add_index :rails_pulse_routes, [ :method, :path, :host_id ], unique: true, name: "index_rails_pulse_routes_on_method_path_and_host"
     connection.add_index :rails_pulse_routes, :path, name: "index_rails_pulse_routes_on_path"
   end
 

--- a/lib/rails_pulse/middleware/request_collector.rb
+++ b/lib/rails_pulse/middleware/request_collector.rb
@@ -44,6 +44,7 @@ module RailsPulse
         tracking_data = {
           method: req.request_method,
           path: req.path,
+          host: req.host,
           duration: duration,
           status: status,
           is_error: status.to_i >= 500,

--- a/lib/rails_pulse/tracker.rb
+++ b/lib/rails_pulse/tracker.rb
@@ -28,10 +28,16 @@ module RailsPulse
           RequestStore.store[:skip_recording_rails_pulse_activity] = true
 
           begin
+            # Find or create host
+            host = if data[:host].present?
+              RailsPulse::Host.find_or_create_by(name: data[:host])
+            end
+
             # Find or create route
             route = RailsPulse::Route.find_or_create_by(
               method: data[:method],
-              path: data[:path]
+              path: data[:path],
+              host_id: host&.id
             )
 
             # Create request record

--- a/lib/tasks/rails_pulse.rake
+++ b/lib/tasks/rails_pulse.rake
@@ -66,4 +66,48 @@ namespace :rails_pulse do
     puts "Total summaries: #{RailsPulse::Summary.count}"
     puts "\nTo keep summaries up to date, schedule RailsPulse::SummaryJob to run hourly"
   end
+
+  desc "Assign orphaned routes (with no host) to a specified host. Usage: rails rails_pulse:backfill_hosts[example.com]"
+  task :backfill_hosts, [:hostname] => :environment do |_t, args|
+    hostname = args[:hostname]
+
+    if hostname.blank?
+      puts "Usage: rails rails_pulse:backfill_hosts[example.com]"
+      puts ""
+      puts "This assigns all routes with no host to the specified hostname."
+      puts "Useful after upgrading from a version that didn't track hosts."
+      next
+    end
+
+    orphaned_routes = RailsPulse::Route.where(host_id: nil)
+    count = orphaned_routes.count
+
+    if count.zero?
+      puts "No orphaned routes found — all routes already have a host assigned."
+      next
+    end
+
+    host = RailsPulse::Host.find_or_create_by!(name: hostname)
+    puts "Assigning #{count} orphaned route(s) to host '#{hostname}'..."
+
+    assigned = 0
+    merged = 0
+
+    orphaned_routes.find_each do |route|
+      existing = RailsPulse::Route.find_by(method: route.method, path: route.path, host_id: host.id)
+
+      if existing
+        # Merge: move requests/summaries to the existing route, then delete the orphan
+        route.requests.update_all(route_id: existing.id)
+        route.summaries.update_all(summarizable_id: existing.id)
+        route.destroy
+        merged += 1
+      else
+        route.update_columns(host_id: host.id)
+        assigned += 1
+      end
+    end
+
+    puts "Done! Assigned #{assigned} route(s), merged #{merged} duplicate(s) into '#{hostname}'."
+  end
 end

--- a/public/rails-pulse-assets/rails-pulse-icons.js
+++ b/public/rails-pulse-assets/rails-pulse-icons.js
@@ -1,5 +1,5 @@
 // Rails Pulse Icons Bundle - Auto-generated
-// Contains 36 SVG icons for Rails Pulse
+// Contains 37 SVG icons for Rails Pulse
 
 (function() {
   'use strict';
@@ -15,6 +15,7 @@
   "chevron-up": "<path d=\"m18 15-6-6-6 6\" />",
   "chevrons-left": "<path d=\"m11 17-5-5 5-5\" /><path d=\"m18 17-5-5 5-5\" />",
   "chevrons-right": "<path d=\"m6 17 5-5-5-5\" /><path d=\"m13 17 5-5-5-5\" />",
+  "globe": "<circle cx=\"12\" cy=\"12\" r=\"10\" /><path d=\"M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20\" /><path d=\"M2 12h20\" />",
   "loader-circle": "<path d=\"M12 2v4\" /><path d=\"m16.2 7.8 2.9-2.9\" /><path d=\"M18 12h4\" /><path d=\"m16.2 16.2 2.9 2.9\" /><path d=\"M12 18v4\" /><path d=\"m4.9 19.1 2.9-2.9\" /><path d=\"M2 12h4\" /><path d=\"m4.9 4.9 2.9 2.9\" />",
   "search": "<path d=\"m21 21-4.34-4.34\" /><circle cx=\"11\" cy=\"11\" r=\"8\" />",
   "list-filter": "<path d=\"M2 5h20\" /><path d=\"M6 12h12\" /><path d=\"M9 19h6\" />",

--- a/scripts/build-icons.js
+++ b/scripts/build-icons.js
@@ -19,6 +19,7 @@ const REQUIRED_ICONS = [
   'chevron-up',
   'chevrons-left',
   'chevrons-right',
+  'globe',
   'loader-circle',
   'search',
   'list-filter',

--- a/vendor/assets/javascripts/rails-pulse-icons.js
+++ b/vendor/assets/javascripts/rails-pulse-icons.js
@@ -1,5 +1,5 @@
 // Rails Pulse Icons Bundle - Auto-generated
-// Contains 36 SVG icons for Rails Pulse
+// Contains 37 SVG icons for Rails Pulse
 
 (function() {
   'use strict';
@@ -15,6 +15,7 @@
   "chevron-up": "<path d=\"m18 15-6-6-6 6\" />",
   "chevrons-left": "<path d=\"m11 17-5-5 5-5\" /><path d=\"m18 17-5-5 5-5\" />",
   "chevrons-right": "<path d=\"m6 17 5-5-5-5\" /><path d=\"m13 17 5-5-5-5\" />",
+  "globe": "<circle cx=\"12\" cy=\"12\" r=\"10\" /><path d=\"M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20\" /><path d=\"M2 12h20\" />",
   "loader-circle": "<path d=\"M12 2v4\" /><path d=\"m16.2 7.8 2.9-2.9\" /><path d=\"M18 12h4\" /><path d=\"m16.2 16.2 2.9 2.9\" /><path d=\"M12 18v4\" /><path d=\"m4.9 19.1 2.9-2.9\" /><path d=\"M2 12h4\" /><path d=\"m4.9 4.9 2.9 2.9\" />",
   "search": "<path d=\"m21 21-4.34-4.34\" /><circle cx=\"11\" cy=\"11\" r=\"8\" />",
   "list-filter": "<path d=\"M2 5h20\" /><path d=\"M6 12h12\" /><path d=\"M9 19h6\" />",


### PR DESCRIPTION
Adds per-host route tracking for multi-domain Rails apps.

## Changes

- **New `rails_pulse_hosts` table** — stores unique hostnames, referenced by routes via `host_id` FK
- **Tracker updated** — automatically creates hosts and associates routes as requests arrive
- **Hosts UI** — new index/show pages showing routes per host with request counts, avg duration, error counts
- **Navigation** — added Hosts link to the dashboard menu
- **Reversible migration** — `up`/`down` methods with deduplication logic in the `down` path
- **Backfill rake task** — `rails rails_pulse:backfill_hosts[example.com]` assigns orphaned routes (from before this feature) to a specified host, auto-merging duplicates
- **README** — documents the upgrade path and backfill options

## Upgrade notes

Existing routes will have `host_id = NULL`. This is safe — the column is optional and the unique index treats NULLs as distinct. New requests will auto-create hosts going forward. Users can optionally run the backfill task to assign old routes to a host.