### PR TITLE
Add missing Requests link to navigation menu

### DIFF
--- a/app/views/layouts/rails_pulse/_menu_items.html.erb
+++ b/app/views/layouts/rails_pulse/_menu_items.html.erb
@@ -8,6 +8,11 @@
   <span class="overflow-ellipsis">Routes</span>
 <% end %>
 
+<%= link_to requests_path, class: 'btn sidebar-menu__button' do %>
+  <%= rails_pulse_icon 'audio-lines', width: '16' %>
+  <span class="overflow-ellipsis">Requests</span>
+<% end %>
+
 <%= link_to queries_path, class: 'btn sidebar-menu__button' do %>
   <%= rails_pulse_icon 'database', width: '16' %>
   <span class="overflow-ellipsis">Queries</span>


### PR DESCRIPTION
The `_menu_items` partial (used by the layout) was missing the Requests link, even though the unused `_sidebar_menu` partial had it. This adds the link between Routes and Queries in the navigation.