### PR TITLE
Prevent Authentication is enabled but no authentication method is con…

### DIFF
--- a/lib/rails_pulse/configuration.rb
+++ b/lib/rails_pulse/configuration.rb
@@ -29,6 +29,15 @@ module RailsPulse
                   :query_service_level_objectives,
                   :warn_on_stale_summaries
 
+    # Override the attr_accessor setter to track explicit assignment.
+    # The default (enabled in production) should not trigger a warning
+    # when no authentication_method is configured — only an explicit
+    # opt-in without a method should warn.
+    def authentication_enabled=(value)
+      @authentication_enabled_explicitly_set = true
+      @authentication_enabled = value
+    end
+
     # Read-only access to thresholds (use setters for validation)
     attr_reader :route_thresholds,
                 :request_thresholds,
@@ -62,6 +71,7 @@ module RailsPulse
       }
       @connects_to = nil
       @authentication_enabled = Rails.env.production?
+      @authentication_enabled_explicitly_set = false
       @authentication_method = nil
       @authentication_redirect_path = "/"
       @tags = [ "ignored", "critical", "experimental" ]
@@ -90,9 +100,9 @@ module RailsPulse
       @warn_on_stale_summaries = true
 
       # Validate defaults eagerly so that a misconfigured initializer raises at
-      # boot time rather than at the first request. All SLO defaults are nil so
-      # validation short-circuits harmlessly here; it becomes meaningful when
-      # RailsPulse.configure yields and sets real values.
+      # boot time rather than at the first request. Auth settings are not
+      # validated against defaults — only when the user explicitly enables
+      # authentication without configuring a method.
       validate_configuration!
     end
 
@@ -204,7 +214,7 @@ module RailsPulse
     end
 
     def validate_authentication_settings!
-      if @authentication_enabled && @authentication_method.nil?
+      if @authentication_enabled && @authentication_enabled_explicitly_set && @authentication_method.nil?
         RailsPulse.logger.warn "Authentication is enabled but no authentication method is configured. This will deny all access."
       end
 

--- a/test/lib/rails_pulse/configuration_test.rb
+++ b/test/lib/rails_pulse/configuration_test.rb
@@ -385,7 +385,7 @@ module RailsPulse
 
     test "validate_authentication_settings! tolerates nil Rails.logger" do
       config = Configuration.new
-      config.instance_variable_set(:@authentication_enabled, true)
+      config.authentication_enabled = true
       config.instance_variable_set(:@authentication_method, nil)
 
       original_logger = Rails.logger


### PR DESCRIPTION
## Summary

Fix spurious "Authentication is enabled but no authentication method is configured" warning at every gem load and Rails boot in production.

The warning fires from default values (`@authentication_enabled = Rails.env.production?`) before the user's `RailsPulse.configure` block has a chance to set `authentication_method`. The controller already has a `fallback_http_basic_auth`, so the "This will deny all access" message was also misleading.

## Type of Change

<!-- Mark the relevant option with an [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)
- [ ] Documentation update
- [ ] Test improvements
- [ ] Build/CI improvements

## Changes Made

<!-- List the specific changes made in this PR -->

- `lib/rails_pulse/configuration.rb` — Added `@authentication_enabled_explicitly_set` flag to track whether the user explicitly assigned `authentication_enabled`, overriding `attr_accessor` setter, and gating the warning on the flag
- `test/lib/rails_pulse/configuration_test.rb` — Updated nil logger test to use the setter so the explicit flag is properly exercised
- Backed out prior `skip_auth:` parameter approach (cleaner to track intent at the setter level)

### Test Results

- [x] All existing tests pass
- [ ] New tests added for new functionality
- [x] Manual testing completed
- [x] Tested across multiple databases (SQLite, PostgreSQL, MySQL)
- [ ] Tested across multiple Rails versions (7.2, 8.0, 8.1)

## Breaking Changes

<!-- List any breaking changes and migration steps if applicable -->

- [x] No breaking changes
- [ ] Breaking changes documented below

<!-- If there are breaking changes, describe them and provide migration steps -->

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Comments added for complex logic
- [ ] Documentation updated (if applicable)
- [x] No new warnings or errors introduced
- [x] Tests added/updated and passing
- [x] Changes work with all supported databases
- [ ] Changes work with all supported Rails versions
- [ ] Asset changes compiled and included (if applicable)

## Additional Notes

<!-- Add any additional context, concerns, or implementation details -->

Boot tested with `RAILS_ENV=production` — the auth warning no longer appears. The deliberate test that verifies the warning (nil Rails.logger scenario) was updated to use the public setter so the explicit flag is set, ensuring the warning still fires for users who explicitly enable auth without a method.
