### PR TITLE
Fix running Rails Pulse as standalone server

### DIFF
--- a/lib/rails_pulse/rack_compat.rb
+++ b/lib/rails_pulse/rack_compat.rb
@@ -1,0 +1,9 @@
+require "rack/session/cookie"
+
+# Rails 8.1 added session.enabled? in ActionDispatch::Flash#commit_flash, but
+# Rack::Session::Abstract::SessionHash (produced by Rack::Session::Cookie) does
+# not define it. This shim adds the missing method so the standalone server does
+# not raise NoMethodError on every request when running against a Rails 8.1 app.
+unless Rack::Session::Abstract::SessionHash.method_defined?(:enabled?)
+  Rack::Session::Abstract::SessionHash.define_method(:enabled?) { true }
+end

--- a/lib/rails_pulse_server.ru
+++ b/lib/rails_pulse_server.ru
@@ -62,6 +62,7 @@ $stderr.sync = true
 # Build the Rack app with session support
 require "rack/session/cookie"
 require "securerandom"
+require_relative "rails_pulse/rack_compat"
 
 # Simple Rack app that just serves the dashboard
 class DashboardApp

--- a/test/lib/rails_pulse/rack_compat_test.rb
+++ b/test/lib/rails_pulse/rack_compat_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+require "rack/session/cookie"
+require "rack/mock_request"
+require "rails_pulse/rack_compat"
+
+module RailsPulse
+  class RackCompatTest < ActiveSupport::TestCase
+    # Rails 8.1 Tests
+
+    test "dashboard rack stack survives Rails 8.1 Flash session.enabled? check" do
+      flash_checker = lambda do |env|
+        env["rack.session"].enabled?
+        [ 200, {}, [ "ok" ] ]
+      end
+
+      app = Rack::Session::Cookie.new(flash_checker,
+        key: "rails_pulse_session",
+        secret: "a" * 64,
+        same_site: :lax,
+        max_age: 86400
+      )
+
+      env = Rack::MockRequest.env_for("/rails_pulse")
+      status, _headers, _body = app.call(env)
+
+      assert_equal 200, status
+    end
+
+    test "Rack session enabled? returns true indicating session is active" do
+      session = Rack::Session::Abstract::SessionHash.new(nil, {})
+
+      assert session.enabled?
+    end
+  end
+end

--- a/test/lib/rails_pulse/rack_compat_test.rb
+++ b/test/lib/rails_pulse/rack_compat_test.rb
@@ -29,7 +29,7 @@ module RailsPulse
     test "Rack session enabled? returns true indicating session is active" do
       session = Rack::Session::Abstract::SessionHash.new(nil, {})
 
-      assert session.enabled?
+      assert_predicate session, :enabled?
     end
   end
 end

--- a/test/lib/rails_pulse/standalone_server_test.rb
+++ b/test/lib/rails_pulse/standalone_server_test.rb
@@ -1,0 +1,95 @@
+require "test_helper"
+require "rack/mock_request"
+
+module RailsPulse
+  class StandaloneServerTest < ActiveSupport::TestCase
+    SERVER_RU = File.expand_path("../../../lib/rails_pulse_server.ru", __dir__)
+    TEST_SECRET = "a" * 64
+
+    def setup
+      @original_secret = ENV["SECRET_KEY_BASE"]
+      ENV["SECRET_KEY_BASE"] = TEST_SECRET
+      @app = build_server_app
+    end
+
+    def teardown
+      ENV["SECRET_KEY_BASE"] = @original_secret
+    end
+
+    # Health Endpoint Tests
+
+    test "health endpoint returns 200 when database is healthy" do
+      RailsPulse::Tracker.stubs(:healthy?).returns(true)
+
+      assert_equal 200, get("/health").status
+    end
+
+    test "health endpoint returns 503 when database is unhealthy" do
+      RailsPulse::Tracker.stubs(:healthy?).returns(false)
+
+      assert_equal 503, get("/health").status
+    end
+
+    test "health endpoint always returns application/json content type" do
+      assert_equal "application/json", get("/health").content_type
+    end
+
+    test "health endpoint body includes all required fields" do
+      body = JSON.parse(get("/health").body)
+
+      %w[status mode database timestamp].each do |field|
+        assert_includes body, field
+      end
+    end
+
+    test "health endpoint mode identifies standalone dashboard" do
+      assert_equal "dashboard", JSON.parse(get("/health").body)["mode"]
+    end
+
+    test "health endpoint status is ok when healthy" do
+      RailsPulse::Tracker.stubs(:healthy?).returns(true)
+
+      assert_equal "ok", JSON.parse(get("/health").body)["status"]
+    end
+
+    test "health endpoint status is unhealthy when database is unavailable" do
+      RailsPulse::Tracker.stubs(:healthy?).returns(false)
+
+      assert_equal "unhealthy", JSON.parse(get("/health").body)["status"]
+    end
+
+    test "health endpoint timestamp is a valid ISO8601 string" do
+      timestamp = JSON.parse(get("/health").body)["timestamp"]
+
+      assert_nothing_raised { Time.iso8601(timestamp) }
+    end
+
+    # Session Compatibility Tests (Rails 8.1)
+
+    test "dashboard request does not raise NoMethodError on session.enabled?" do
+      assert_nothing_raised { get("/") }
+    end
+
+    test "dashboard response sets a session cookie" do
+      assert_not_nil get("/").headers["Set-Cookie"]
+    end
+
+    # Server Configuration Tests
+
+    test "server raises when SECRET_KEY_BASE is not set" do
+      ENV.delete("SECRET_KEY_BASE")
+
+      assert_raises(RuntimeError) { build_server_app }
+    end
+
+    private
+
+    def build_server_app
+      Rack::Builder.parse_file(SERVER_RU)
+    end
+
+    def get(path)
+      Rack::MockRequest.new(@app).get(path)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes a crash affecting all requests to the standalone Rails Pulse server (`rails_pulse_server.ru`) when running against a Rails 8.1 app. Rails 8.1 introduced a `session.enabled?` guard in `ActionDispatch::Flash#commit_flash`, but `Rack::Session::Cookie` — used by the standalone server — populates `env["rack.session"]` with a plain `Rack::Session::Abstract::SessionHash` that does not define `enabled?`. This causes a `NoMethodError` on every request.

The fix adds a targeted compatibility shim in `lib/rails_pulse/rack_compat.rb` that defines `enabled?` on `Rack::Session::Abstract::SessionHash` if absent, using an idempotency guard so it becomes a no-op if Rack ever adds the method natively.

Closes #155.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)
- [ ] Documentation update
- [ ] Test improvements
- [ ] Build/CI improvements

## Changes Made

- `lib/rails_pulse/rack_compat.rb` — new file; defines `enabled?` on `Rack::Session::Abstract::SessionHash` for Rails 8.1 compatibility
- `lib/rails_pulse_server.ru` — requires `rack_compat` before `Rack::Session::Cookie` middleware is added, covering all three boot paths
- `test/lib/rails_pulse/rack_compat_test.rb` — verifies the shim works in isolation via `Rack::MockRequest` through a `Rack::Session::Cookie` stack
- `test/lib/rails_pulse/standalone_server_test.rb` — new integration test suite that loads the real `.ru` file via `Rack::Builder.parse_file` and exercises the health endpoint, session compatibility, routing, and server configuration

### Test Results

- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Manual testing completed
- [ ] Tested across multiple databases (SQLite, PostgreSQL, MySQL)
- [ ] Tested across multiple Rails versions (7.2, 8.0, 8.1)

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

## Screenshots

N/A

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Comments added for complex logic
- [ ] Documentation updated (if applicable)
- [x] No new warnings or errors introduced
- [x] Tests added/updated and passing
- [ ] Changes work with all supported databases
- [ ] Changes work with all supported Rails versions
- [ ] Asset changes compiled and included (if applicable)

