### PR TITLE
Improve saving data

### DIFF
--- a/app/models/rails_pulse/operation.rb
+++ b/app/models/rails_pulse/operation.rb
@@ -157,7 +157,7 @@ module RailsPulse
       hashed = Digest::MD5.hexdigest(normalized)
 
       unless self.query&.hashed_sql == hashed
-        self.query = RailsPulse::Query.create_or_find_by(hashed_sql: hashed) do |q|
+        self.query = RailsPulse::Query.find_or_create_by(hashed_sql: hashed) do |q|
           q.normalized_sql = normalized
         end
       end

--- a/app/models/rails_pulse/route.rb
+++ b/app/models/rails_pulse/route.rb
@@ -13,7 +13,7 @@ module RailsPulse
     validates :path, presence: true
 
     def self.by_method_and_path(method, path)
-      create_or_find_by(method: method, path: path) || find_by!(method: method, path: path)
+      find_or_create_by!(method: method, path: path)
     end
 
     def self.ransackable_attributes(auth_object = nil)

--- a/lib/rails_pulse/job_run_collector.rb
+++ b/lib/rails_pulse/job_run_collector.rb
@@ -79,10 +79,10 @@ module RailsPulse
       end
 
       def find_or_create_job(active_job)
-        RailsPulse::Job.create_or_find_by!(name: job_class_name(active_job)) do |job|
+        RailsPulse::Job.find_or_create_by!(name: job_class_name(active_job)) do |job|
           job.queue_name = active_job.queue_name
         end
-      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
+      rescue ActiveRecord::RecordNotUnique
         RailsPulse::Job.find_by!(name: job_class_name(active_job))
       end
 

--- a/test/services/rails_pulse/job_run_collector_test.rb
+++ b/test/services/rails_pulse/job_run_collector_test.rb
@@ -169,7 +169,7 @@ module RailsPulse
 
       RailsPulse::Job.create!(name: FakeJob.name, queue_name: "default")
 
-      RailsPulse::Job.define_singleton_method(:create_or_find_by!) do |*args, **kwargs, &block|
+      RailsPulse::Job.define_singleton_method(:find_or_create_by!) do |*args, **kwargs, &block|
         raise ActiveRecord::RecordNotUnique, "duplicate"
       end
 
@@ -177,24 +177,7 @@ module RailsPulse
 
       assert_equal FakeJob.name, result.name
     ensure
-      RailsPulse::Job.singleton_class.remove_method(:create_or_find_by!) rescue nil
-    end
-
-    test "find_or_create_job recovers from RecordInvalid" do
-      RailsPulse::Job.where(name: FakeJob.name).delete_all
-
-      RailsPulse::Job.create!(name: FakeJob.name, queue_name: "default")
-      existing = RailsPulse::Job.find_by!(name: FakeJob.name)
-
-      RailsPulse::Job.define_singleton_method(:create_or_find_by!) do |*args, **kwargs, &block|
-        raise ActiveRecord::RecordInvalid.new(existing)
-      end
-
-      result = RailsPulse::JobRunCollector.send(:find_or_create_job, FakeJob.new)
-
-      assert_equal FakeJob.name, result.name
-    ensure
-      RailsPulse::Job.singleton_class.remove_method(:create_or_find_by!) rescue nil
+      RailsPulse::Job.singleton_class.remove_method(:find_or_create_by!) rescue nil
     end
 
     test "create_job_run creates new job run record" do

--- a/test/services/rails_pulse/job_run_collector_test.rb
+++ b/test/services/rails_pulse/job_run_collector_test.rb
@@ -1,5 +1,3 @@
-require "securerandom"
-
 require "test_helper"
 
 module RailsPulse
@@ -92,7 +90,6 @@ module RailsPulse
       first_job = FakeJob.new(job_id: job_id, executions: 1)
 
       RailsPulse::JobRunCollector.track(first_job) do
-        # First execution succeeds
       end
 
       first_run = RailsPulse::JobRun.find_by(run_id: job_id)
@@ -104,7 +101,6 @@ module RailsPulse
 
       assert_no_difference -> { RailsPulse::JobRun.count } do
         RailsPulse::JobRunCollector.track(retry_job) do
-          # Retry execution
         end
       end
 
@@ -143,7 +139,7 @@ module RailsPulse
       assert_nil run.arguments
     end
 
-    # Race Condition Tests
+    # find_or_create_job Tests
 
     test "find_or_create_job creates new job record" do
       RailsPulse::Job.where(name: FakeJob.name).delete_all
@@ -164,22 +160,6 @@ module RailsPulse
       assert_equal existing.id, result.id
     end
 
-    test "find_or_create_job recovers from RecordNotUnique" do
-      RailsPulse::Job.where(name: FakeJob.name).delete_all
-
-      RailsPulse::Job.create!(name: FakeJob.name, queue_name: "default")
-
-      RailsPulse::Job.define_singleton_method(:find_or_create_by!) do |*args, **kwargs, &block|
-        raise ActiveRecord::RecordNotUnique, "duplicate"
-      end
-
-      result = RailsPulse::JobRunCollector.send(:find_or_create_job, FakeJob.new)
-
-      assert_equal FakeJob.name, result.name
-    ensure
-      RailsPulse::Job.singleton_class.remove_method(:find_or_create_by!) rescue nil
-    end
-
     test "create_job_run creates new job run record" do
       job = rails_pulse_jobs(:mailer_job)
       fake = FakeJob.new
@@ -191,7 +171,7 @@ module RailsPulse
       assert_equal fake.job_id, run.run_id
     end
 
-    test "create_job_run recovers from RecordNotUnique" do
+    test "create_job_run finds existing run when job_id already recorded" do
       job = rails_pulse_jobs(:mailer_job)
       fake = FakeJob.new
       run_id = "race-run-#{SecureRandom.hex(4)}"
@@ -199,15 +179,9 @@ module RailsPulse
 
       existing = RailsPulse::JobRun.create!(run_id: run_id, job: job, status: "running", occurred_at: Time.current)
 
-      RailsPulse::JobRun.define_singleton_method(:create_or_find_by) do |*args, **kwargs, &block|
-        raise ActiveRecord::RecordNotUnique, "duplicate"
-      end
-
       result = RailsPulse::JobRunCollector.send(:create_job_run, job, fake, "test", Time.current)
 
       assert_equal existing.id, result.id
-    ensure
-      RailsPulse::JobRun.singleton_class.remove_method(:create_or_find_by) rescue nil
     end
 
     test "active job integration wraps perform now" do

--- a/test/tracker_test.rb
+++ b/test/tracker_test.rb
@@ -40,28 +40,12 @@ class RailsPulse::TrackerTest < ActiveSupport::TestCase
     assert_equal 1, request.operations.count
   end
 
-  test "creates route and request records with operations" do
-    RailsPulse::Tracker.track_request(@tracking_data)
-
-    route = RailsPulse::Route.find_by(method: @tracking_data[:method], path: @tracking_data[:path])
-
-    assert_not_nil route
-
-    request = RailsPulse::Request.find_by(request_uuid: @tracking_data[:request_uuid])
-
-    assert_not_nil request
-    assert_equal 1, request.operations.count
-  end
-
   test "handles errors gracefully" do
-    # Stub to raise an error
-    RailsPulse::Route.stubs(:find_or_create_by).raises(StandardError, "DB Error")
+    RailsPulse::Route.stubs(:find_by).raises(StandardError, "DB Error")
 
     assert_nothing_raised do
       RailsPulse::Tracker.track_request(@tracking_data)
     end
-
-    RailsPulse::Route.unstub(:find_or_create_by)
   end
 
   test "healthy? returns true when database is connected" do


### PR DESCRIPTION
## Summary

This switches out some uses of `create_or_find_by` to `find_or_create_by` to prevent a lot of warnings like this:


```
ERROR:  duplicate key value violates unique constraint “index_rails_pulse_jobs_on_name
```
