### PR TITLE
Copy schema file on upgrade

### DIFF
--- a/db/rails_pulse_schema.rb
+++ b/db/rails_pulse_schema.rb
@@ -2,7 +2,7 @@
 # This file contains the complete schema for Rails Pulse tables
 # Load with: rails db:schema:load_rails_pulse or db:prepare
 
-RailsPulse::Schema ||= lambda do |connection|
+RailsPulse::Schema = lambda do |connection|
   adapter = connection.adapter_name.downcase
   # Skip if all tables already exist to prevent conflicts
   required_tables = [ :rails_pulse_routes, :rails_pulse_queries, :rails_pulse_requests, :rails_pulse_operations, :rails_pulse_jobs, :rails_pulse_job_runs, :rails_pulse_summaries, :rails_pulse_deployments ]
@@ -226,7 +226,7 @@ RailsPulse::Schema ||= lambda do |connection|
   if newly_created.any?
     puts "[RailsPulse::Schema] Successfully created tables: #{newly_created.join(', ')}"
   end
-end
+end unless defined?(RailsPulse::Schema)
 
 if defined?(RailsPulse::ApplicationRecord)
   RailsPulse::Schema.call(RailsPulse::ApplicationRecord.connection)

--- a/lib/generators/rails_pulse/templates/db/rails_pulse_schema.rb
+++ b/lib/generators/rails_pulse/templates/db/rails_pulse_schema.rb
@@ -2,7 +2,7 @@
 # This file contains the complete schema for Rails Pulse tables
 # Load with: rails db:schema:load_rails_pulse or db:prepare
 
-RailsPulse::Schema ||= lambda do |connection|
+RailsPulse::Schema = lambda do |connection|
   adapter = connection.adapter_name.downcase
   # Skip if all tables already exist to prevent conflicts
   required_tables = [ :rails_pulse_routes, :rails_pulse_queries, :rails_pulse_requests, :rails_pulse_operations, :rails_pulse_jobs, :rails_pulse_job_runs, :rails_pulse_summaries, :rails_pulse_deployments ]
@@ -226,7 +226,7 @@ RailsPulse::Schema ||= lambda do |connection|
   if newly_created.any?
     puts "[RailsPulse::Schema] Successfully created tables: #{newly_created.join(', ')}"
   end
-end
+end unless defined?(RailsPulse::Schema)
 
 if defined?(RailsPulse::ApplicationRecord)
   RailsPulse::Schema.call(RailsPulse::ApplicationRecord.connection)

--- a/lib/generators/rails_pulse/upgrade_generator.rb
+++ b/lib/generators/rails_pulse/upgrade_generator.rb
@@ -96,6 +96,10 @@ module RailsPulse
 
       # Shared upgrade logic for both single and separate database setups
       def upgrade_installation(migration_dir:, next_steps:)
+        # Refresh the schema file so fresh databases (test, CI) built from
+        # db/rails_pulse_schema.rb include all current columns and tables.
+        copy_file "db/rails_pulse_schema.rb", "db/rails_pulse_schema.rb"
+
         gem_migrations = get_gem_migrations
         existing_migrations = get_user_migrations(migration_dir)
         new_migrations = gem_migrations - existing_migrations

--- a/test/dummy/db/rails_pulse_schema.rb
+++ b/test/dummy/db/rails_pulse_schema.rb
@@ -2,7 +2,7 @@
 # This file contains the complete schema for Rails Pulse tables
 # Load with: rails db:schema:load_rails_pulse or db:prepare
 
-RailsPulse::Schema ||= lambda do |connection|
+RailsPulse::Schema = lambda do |connection|
   adapter = connection.adapter_name.downcase
   # Skip if all tables already exist to prevent conflicts
   required_tables = [ :rails_pulse_routes, :rails_pulse_queries, :rails_pulse_requests, :rails_pulse_operations, :rails_pulse_jobs, :rails_pulse_job_runs, :rails_pulse_summaries, :rails_pulse_deployments ]
@@ -226,7 +226,7 @@ RailsPulse::Schema ||= lambda do |connection|
   if newly_created.any?
     puts "[RailsPulse::Schema] Successfully created tables: #{newly_created.join(', ')}"
   end
-end
+end unless defined?(RailsPulse::Schema)
 
 if defined?(RailsPulse::ApplicationRecord)
   RailsPulse::Schema.call(RailsPulse::ApplicationRecord.connection)

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -22,7 +22,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     assert_file "db/rails_pulse_schema.rb" do |content|
-      assert_match(/RailsPulse::Schema ||= lambda/, content)
+      assert_match(/RailsPulse::Schema = lambda/, content)
       assert_match(/create_table :rails_pulse_routes/, content)
     end
   end


### PR DESCRIPTION
## Summary

Two follow-up fixes from #166 (separate-database upgrade issues).

1. **Upgrade generator now refreshes `db/rails_pulse_schema.rb`** This file is used to build fresh databases on separate-DB setups, so leaving it stale after an upgrade silently produced databases missing new columns but fully marked as migrated.
2. **Schema file lint fix** `RailsPulse::Schema ||= lambda` triggers `Lint/OrAssignmentToConstant` in rubocop/standardrb. Since the file is copied into the host app it showed up in users' own lint runs. 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `lib/generators/rails_pulse/upgrade_generator.rb` — refresh `db/rails_pulse_schema.rb` at the start of `upgrade_installation` (both single-DB and separate-DB paths)
- `db/rails_pulse_schema.rb`, generator template, and dummy app copy — `||= lambda do...end` → `= lambda do...end unless defined?(RailsPulse::Schema)`
- `test/generators/install_generator_test.rb` — update regex assertion to match new form

### Test Results

- [x] All existing tests pass
- [x] Manual testing completed

## Breaking Changes

- [x] No breaking changes

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] No new warnings or errors introduced
- [x] Tests added/updated and passing

## Additional Notes

Reported by @thedumbtechguy in #166. 