### PR TITLE
Fix db:migrate failure when Rails Pulse tables already exist (#189)

### DIFF
--- a/bin/test_generators
+++ b/bin/test_generators
@@ -203,7 +203,12 @@ class GeneratorTester
       # Run db:prepare
       run_command "bin/rails db:prepare RAILS_ENV=test"
 
-      verify_tables_exist("Tables created successfully")
+      verify_tables_exist("Tables created successfully", separate: true)
+
+      # db:migrate must succeed when pulse tables already exist (issue #189)
+      run_command "bin/rails db:migrate RAILS_ENV=test"
+
+      verify_tables_exist("Tables still exist after db:migrate", separate: true)
     end
   end
 
@@ -275,10 +280,21 @@ class GeneratorTester
     end
   end
 
-  def verify_tables_exist(description)
+  def verify_tables_exist(description, separate: false)
     Dir.chdir(test_dir) do
+      runner_code = if separate
+        <<~RUBY.tr("\n", " ")
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: 'test', name: 'rails_pulse', include_hidden: true);
+          ActiveRecord::Tasks::DatabaseTasks.with_temporary_connection(db_config) do |conn|
+            puts conn.table_exists?(:rails_pulse_routes) && conn.table_exists?(:rails_pulse_queries) && conn.table_exists?(:rails_pulse_requests)
+          end
+        RUBY
+      else
+        'puts RailsPulse::Route.table_exists? && RailsPulse::Query.table_exists? && RailsPulse::Request.table_exists?'
+      end
+
       result = run_command(
-        "bin/rails runner -e test \"puts RailsPulse::Route.table_exists? && RailsPulse::Query.table_exists? && RailsPulse::Request.table_exists?\"",
+        "bin/rails runner -e test \"#{runner_code}\"",
         capture: true
       )
 

--- a/docs/database_setup.md
+++ b/docs/database_setup.md
@@ -38,12 +38,22 @@ Then configure `config/database.yml`:
 
 ```yaml
 development:
+  primary:
+    <<: *default
+    database: storage/development.sqlite3
   rails_pulse:
     <<: *default
     database: storage/development_rails_pulse.sqlite3
     migrations_paths: db/rails_pulse_migrate
+    database_tasks: false
 
 production:
+  primary:
+    adapter: postgresql
+    database: myapp_production
+    username: <%= ENV['DB_USERNAME'] %>
+    password: <%= ENV['DB_PASSWORD'] %>
+    host: <%= ENV['DB_HOST'] %>
   rails_pulse:
     adapter: postgresql
     database: myapp_rails_pulse
@@ -51,7 +61,15 @@ production:
     password: <%= ENV['DB_PASSWORD'] %>
     host: <%= ENV['DB_HOST'] %>
     migrations_paths: db/rails_pulse_migrate
+    database_tasks: false
 ```
+
+Also uncomment `config.connects_to` in `config/initializers/rails_pulse.rb` so Rails Pulse
+models use the separate database connection.
+
+Setting `database_tasks: false` prevents Rails from loading `db/rails_pulse_structure.sql`
+during `db:migrate`. Rails Pulse manages the pulse database schema via the idempotent
+`db/rails_pulse_schema.rb` file instead.
 
 Finally, create the database:
 
@@ -169,6 +187,7 @@ rails db:migrate  # Idempotent - safe to run even if tables exist
 git checkout feature-branch
 bundle install
 rails db:prepare  # Schema file will skip existing tables
+rails db:migrate  # Safe — uses idempotent schema load, not structure.sql
 ```
 
 **If you want a clean state:**

--- a/lib/generators/rails_pulse/install_generator.rb
+++ b/lib/generators/rails_pulse/install_generator.rb
@@ -74,13 +74,18 @@ module RailsPulse
           1. Add Rails Pulse database configuration to config/database.yml:
 
              #{Rails.env}:
+               primary:
+                 <<: *default
+                 database: storage/#{Rails.env}.sqlite3
                rails_pulse:
                  <<: *default
                  database: storage/#{Rails.env}_rails_pulse.sqlite3
                  migrations_paths: db/rails_pulse_migrate
+                 database_tasks: false
 
-          2. Run: rails db:prepare (creates database and loads schema)
-          3. Restart your Rails server
+          2. Uncomment config.connects_to in config/initializers/rails_pulse.rb
+          3. Run: rails db:prepare (creates database and loads schema)
+          4. Restart your Rails server
 
           The schema file db/rails_pulse_schema.rb is your single source of truth.
           Future upgrades will automatically copy new migrations to db/rails_pulse_migrate/

--- a/lib/generators/rails_pulse/templates/rails_pulse.rb
+++ b/lib/generators/rails_pulse/templates/rails_pulse.rb
@@ -169,7 +169,8 @@ RailsPulse.configure do |config|
   # Don't forget to add the database configuration to config/database.yml:
   #
   # production:
-  #   # ... your main database config ...
+  #   primary:
+  #     # ... your main database config ...
   #   rails_pulse:
   #     adapter: postgresql  # or mysql2, sqlite3
   #     database: myapp_rails_pulse_production
@@ -177,6 +178,8 @@ RailsPulse.configure do |config|
   #     password: <%= Rails.application.credentials.dig(:rails_pulse, :database_password) %>
   #     host: localhost
   #     pool: 5
+  #     migrations_paths: db/rails_pulse_migrate
+  #     database_tasks: false
 
   # ====================================================================================================
   #                                            AUTHENTICATION

--- a/lib/tasks/rails_pulse.rake
+++ b/lib/tasks/rails_pulse.rake
@@ -2,33 +2,43 @@ namespace :db do
   namespace :schema do
     desc "Load Rails Pulse schema (for separate database setup only)"
     task load_rails_pulse: :environment do
-      schema_file = Rails.root.join("db/rails_pulse_schema.rb")
-
-      # Only load schema if using separate database setup
-      if separate_database_setup?
-        if schema_file.exist?
-          load schema_file
-          puts "Rails Pulse schema loaded successfully"
-          # Record any copied migrations as already applied so they don't show as
-          # pending after a fresh schema load. The schema file creates all tables and
-          # columns directly, so the incremental migrations are logically already done.
-          record_rails_pulse_migrations_applied
-        else
-          puts "Rails Pulse schema file not found. Run: rails generate rails_pulse:install --database=separate"
-        end
-      else
-        puts "Single database setup detected. Rails Pulse tables managed via regular migrations."
-      end
+      load_rails_pulse_schema
     end
   end
 
-  # Hook into common database tasks only for separate database setup
-  task prepare: :environment do
-    Rake::Task["db:schema:load_rails_pulse"].invoke if separate_database_setup?
+  namespace :migrate do
+    desc "Migrate Rails Pulse database for current environment"
+    task rails_pulse: :load_config do
+      migrate_rails_pulse_database
+    end
   end
+end
 
-  task setup: :environment do
-    Rake::Task["db:schema:load_rails_pulse"].invoke if separate_database_setup?
+# Hook into common database tasks only for separate database setup.
+# Use enhance (not task redefinition) so Rails' built-in actions still run.
+if Rake::Task.task_defined?("db:prepare")
+  Rake::Task["db:prepare"].enhance do
+    next unless separate_database_setup?
+
+    Rake::Task["db:schema:load_rails_pulse"].reenable
+    Rake::Task["db:schema:load_rails_pulse"].invoke
+  end
+end
+
+if Rake::Task.task_defined?("db:setup")
+  Rake::Task["db:setup"].enhance do
+    next unless separate_database_setup?
+
+    Rake::Task["db:schema:load_rails_pulse"].reenable
+    Rake::Task["db:schema:load_rails_pulse"].invoke
+  end
+end
+
+if Rake::Task.task_defined?("db:migrate")
+  Rake::Task["db:migrate"].enhance do
+    next unless separate_database_setup?
+
+    migrate_rails_pulse_database
   end
 end
 
@@ -55,38 +65,106 @@ def separate_database_setup?
   (Rails.application.config.database_configuration.dig(Rails.env, "rails_pulse").present?)
 end
 
+def rails_pulse_db_config
+  ActiveRecord::Base.configurations.configs_for(
+    env_name: Rails.env,
+    name: "rails_pulse",
+    include_hidden: true
+  )
+end
+
+def ensure_rails_pulse_database
+  db_config = rails_pulse_db_config
+  return unless db_config
+
+  ActiveRecord::Tasks::DatabaseTasks.create(db_config)
+rescue ActiveRecord::DatabaseAlreadyExists
+  # Database already exists — nothing to do.
+end
+
+def with_rails_pulse_connection
+  db_config = rails_pulse_db_config
+  return unless db_config
+
+  if defined?(RailsPulse::ApplicationRecord) && RailsPulse.connects_to
+    yield RailsPulse::ApplicationRecord.connection
+  else
+    ActiveRecord::Tasks::DatabaseTasks.with_temporary_connection(db_config) do |connection|
+      yield connection
+    end
+  end
+end
+
+def load_rails_pulse_schema
+  schema_file = Rails.root.join("db/rails_pulse_schema.rb")
+
+  unless separate_database_setup?
+    puts "Single database setup detected. Rails Pulse tables managed via regular migrations."
+    return
+  end
+
+  unless schema_file.exist?
+    puts "Rails Pulse schema file not found. Run: rails generate rails_pulse:install --database=separate"
+    return
+  end
+
+  ensure_rails_pulse_database
+
+  load schema_file unless defined?(RailsPulse::Schema)
+
+  with_rails_pulse_connection do |connection|
+    RailsPulse::Schema.call(connection)
+  end
+
+  puts "Rails Pulse schema loaded successfully"
+
+  # Record any copied migrations as already applied so they don't show as
+  # pending after a fresh schema load. The schema file creates all tables and
+  # columns directly, so the incremental migrations are logically already done.
+  record_rails_pulse_migrations_applied
+end
+
+def migrate_rails_pulse_database
+  load_rails_pulse_schema
+
+  db_config = rails_pulse_db_config
+  return unless db_config
+
+  ActiveRecord::Tasks::DatabaseTasks.with_temporary_connection(db_config) do
+    ActiveRecord::Tasks::DatabaseTasks.migrate
+  end
+end
+
 # After a schema load, insert version numbers for any migration files already in
 # db/rails_pulse_migrate/ into schema_migrations so Rails does not report them as
 # pending. The schema already includes every column those migrations would add, so
 # running them would be a no-op — but Rails still needs the version recorded.
 def record_rails_pulse_migrations_applied
-  return unless defined?(RailsPulse::ApplicationRecord)
-
   migrations_path = Rails.root.join("db/rails_pulse_migrate")
   return unless migrations_path.exist?
 
-  connection = RailsPulse::ApplicationRecord.connection
-
-  # Create schema_migrations if this is a brand-new database that has not yet
-  # had any migrations run against it (e.g. just after db:create).
-  unless connection.table_exists?(:schema_migrations)
-    connection.create_table :schema_migrations, id: false do |t|
-      t.string :version, null: false
+  with_rails_pulse_connection do |connection|
+    # Create schema_migrations if this is a brand-new database that has not yet
+    # had any migrations run against it (e.g. just after db:create).
+    unless connection.table_exists?(:schema_migrations)
+      connection.create_table :schema_migrations, id: false do |t|
+        t.string :version, null: false
+      end
+      connection.add_index :schema_migrations, :version,
+        unique: true, name: "unique_schema_migrations"
     end
-    connection.add_index :schema_migrations, :version,
-      unique: true, name: "unique_schema_migrations"
-  end
 
-  Dir.glob("#{migrations_path}/*.rb").sort.each do |file|
-    version = File.basename(file, ".rb").split("_").first
-    next if connection.select_values(
-      "SELECT version FROM schema_migrations WHERE version = #{connection.quote(version)}"
-    ).any?
+    Dir.glob("#{migrations_path}/*.rb").sort.each do |file|
+      version = File.basename(file, ".rb").split("_").first
+      next if connection.select_values(
+        "SELECT version FROM schema_migrations WHERE version = #{connection.quote(version)}"
+      ).any?
 
-    connection.execute(
-      "INSERT INTO schema_migrations (version) VALUES (#{connection.quote(version)})"
-    )
-    puts "[RailsPulse] Marked migration #{version} as applied (schema already up to date)"
+      connection.execute(
+        "INSERT INTO schema_migrations (version) VALUES (#{connection.quote(version)})"
+      )
+      puts "[RailsPulse] Marked migration #{version} as applied (schema already up to date)"
+    end
   end
 rescue => e
   warn "[RailsPulse] Could not mark migrations as applied: #{e.message}"

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -47,56 +47,74 @@ default: &default
   <% end %>
 
 development:
-  <<: *default
-  <% if adapter == 'sqlite3' %>
-  database: storage/development.sqlite3
-  <% elsif adapter == 'postgresql' %>
-  database: <%= ENV.fetch('POSTGRES_DATABASE', 'rails_pulse_development') %>
-  <% elsif adapter == 'mysql' || adapter == 'mysql2' %>
-  database: <%= ENV.fetch('MYSQL_DATABASE', 'rails_pulse_development') %>
-  <% else %>
-  database: rails_pulse_development
-  <% end %>
+  primary:
+    <<: *default
+    <% if adapter == 'sqlite3' %>
+    database: storage/development.sqlite3
+    <% elsif adapter == 'postgresql' %>
+    database: <%= ENV.fetch('POSTGRES_DATABASE', 'rails_pulse_development') %>
+    <% elsif adapter == 'mysql' || adapter == 'mysql2' %>
+    database: <%= ENV.fetch('MYSQL_DATABASE', 'rails_pulse_development') %>
+    <% else %>
+    database: rails_pulse_development
+    <% end %>
   rails_pulse:
     <<: *default
     database: storage/development_rails_pulse.sqlite3
     migrations_paths: db/rails_pulse_migrate
+    database_tasks: false
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
-  <% if adapter == 'sqlite3' %>
-  database: storage/test.sqlite3
+  primary:
+    <<: *default
+    <% if adapter == 'sqlite3' %>
+    database: storage/test.sqlite3
+    <% elsif adapter == 'postgresql' %>
+    database: <%= ENV.fetch('POSTGRES_TEST_DATABASE', 'rails_pulse_test') %>
+    <% elsif adapter == 'mysql' || adapter == 'mysql2' %>
+    database: <%= ENV.fetch('MYSQL_TEST_DATABASE', 'rails_pulse_test') %>
+    <% else %>
+    database: rails_pulse_test
+    <% end %>
   rails_pulse:
     <<: *default
+    <% if adapter == 'sqlite3' %>
     database: storage/test_rails_pulse.sqlite3
-    migrations_paths: db/rails_pulse_migrate
-  <% elsif adapter == 'postgresql' %>
-  database: <%= ENV.fetch('POSTGRES_TEST_DATABASE', 'rails_pulse_test') %>
-  rails_pulse:
-    <<: *default
+    <% elsif adapter == 'postgresql' %>
     database: <%= ENV.fetch('POSTGRES_TEST_RAILS_PULSE_DATABASE', 'rails_pulse_test_rails_pulse') %>
-    migrations_paths: db/rails_pulse_migrate
-  <% elsif adapter == 'mysql' || adapter == 'mysql2' %>
-  database: <%= ENV.fetch('MYSQL_TEST_DATABASE', 'rails_pulse_test') %>
-  rails_pulse:
-    <<: *default
+    <% elsif adapter == 'mysql' || adapter == 'mysql2' %>
     database: <%= ENV.fetch('MYSQL_TEST_RAILS_PULSE_DATABASE', 'rails_pulse_test_rails_pulse') %>
+    <% else %>
+    database: rails_pulse_test_rails_pulse
+    <% end %>
     migrations_paths: db/rails_pulse_migrate
-  <% else %>
-  database: rails_pulse_test
-  <% end %>
+    database_tasks: false
 
 production:
-  <<: *default
-  <% if adapter == 'sqlite3' %>
-  database: storage/production.sqlite3
-  <% elsif adapter == 'postgresql' %>
-  database: <%= ENV.fetch('POSTGRES_PRODUCTION_DATABASE', 'rails_pulse_production') %>
-  <% elsif adapter == 'mysql' || adapter == 'mysql2' %>
-  database: <%= ENV.fetch('MYSQL_PRODUCTION_DATABASE', 'rails_pulse_production') %>
-  <% else %>
-  database: rails_pulse_production
-  <% end %>
+  primary:
+    <<: *default
+    <% if adapter == 'sqlite3' %>
+    database: storage/production.sqlite3
+    <% elsif adapter == 'postgresql' %>
+    database: <%= ENV.fetch('POSTGRES_PRODUCTION_DATABASE', 'rails_pulse_production') %>
+    <% elsif adapter == 'mysql' || adapter == 'mysql2' %>
+    database: <%= ENV.fetch('MYSQL_PRODUCTION_DATABASE', 'rails_pulse_production') %>
+    <% else %>
+    database: rails_pulse_production
+    <% end %>
+  rails_pulse:
+    <<: *default
+    <% if adapter == 'sqlite3' %>
+    database: storage/production_rails_pulse.sqlite3
+    <% elsif adapter == 'postgresql' %>
+    database: <%= ENV.fetch('POSTGRES_PRODUCTION_RAILS_PULSE_DATABASE', 'rails_pulse_production_rails_pulse') %>
+    <% elsif adapter == 'mysql' || adapter == 'mysql2' %>
+    database: <%= ENV.fetch('MYSQL_PRODUCTION_RAILS_PULSE_DATABASE', 'rails_pulse_production_rails_pulse') %>
+    <% else %>
+    database: rails_pulse_production_rails_pulse
+    <% end %>
+    migrations_paths: db/rails_pulse_migrate
+    database_tasks: false

--- a/test/lib/tasks/rails_pulse_test.rb
+++ b/test/lib/tasks/rails_pulse_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "rake"
+require "fileutils"
 
 class RailsPulseRakeTest < ActiveSupport::TestCase
   # Disable parallelization for rake task tests
@@ -193,6 +194,60 @@ class RailsPulseRakeTest < ActiveSupport::TestCase
 
     # Either true or false is valid depending on actual config
     assert_includes [ true, false ], result
+  end
+
+  test "db:migrate hook is defined" do
+    task = Rake::Task["db:migrate"]
+
+    assert_kind_of Rake::Task, task
+  end
+
+  test "db:migrate:rails_pulse task is defined" do
+    task = Rake::Task["db:migrate:rails_pulse"]
+
+    assert_kind_of Rake::Task, task
+  end
+
+  test "rails_pulse database config has database_tasks disabled" do
+    skip "Requires separate database setup" unless separate_database_setup?
+
+    db_config = rails_pulse_db_config
+    skip "Requires rails_pulse database config" unless db_config
+
+    refute db_config.database_tasks?, "rails_pulse database should have database_tasks: false"
+  end
+
+  test "db:migrate succeeds when rails pulse tables already exist on separate database" do
+    skip "Requires separate database setup" unless separate_database_setup?
+
+    db_config = rails_pulse_db_config
+    skip "Requires rails_pulse database config" unless db_config
+
+    structure_sql = Rails.root.join("db/rails_pulse_structure.sql")
+
+    begin
+      # Pre-create pulse tables via the idempotent Ruby schema loader
+      reenable_and_capture("db:schema:load_rails_pulse") do
+        Rake::Task["db:schema:load_rails_pulse"].invoke
+      end
+
+      # Simulate a structure dump that would cause duplicate-relation errors
+      File.write(structure_sql, <<~SQL)
+        CREATE TABLE rails_pulse_deployments (
+          id bigserial PRIMARY KEY
+        );
+      SQL
+
+      output = reenable_and_capture("db:migrate") do
+        Rake::Task["db:migrate"].invoke
+      end
+
+      refute_match(/relation .* already exists/i, output)
+      assert output.include?("already exist") || output.include?("schema loaded successfully") ||
+        output.include?("migrated") || output.empty?
+    ensure
+      FileUtils.rm_f(structure_sql)
+    end
   end
 
   test "db:prepare hook is defined" do


### PR DESCRIPTION
Reproduce and fix GitHub issue #189: `bundle exec rails db:migrate` fails with `relation "rails_pulse_deployments" already exists` when loading `/db/rails_pulse_structure.sql`, even though `[RailsPulse::Schema]` detects existing tables and skips schema load during `db:prepare`.

Reference: https://github.com/railspulse-org/rails_pulse/issues/189

## Requirements
1. Reproduce the failure: set up an app with Rails Pulse where pulse tables already exist (via install generator or prior db:prepare), then run `bundle exec rails db:migrate` and confirm the psql error on `rails_pulse_structure.sql`.
2. Identify why `db:migrate` still executes `rails_pulse_structure.sql` when tables exist, while `db:prepare` correctly skips schema load.
3. Fix so `db:migrate` is idempotent when pulse tables already exist — no duplicate-relation errors.
4. Ensure the pulse database reports `database_tasks?: false` as intended; audit whether `migrations_paths` without `database_tasks: false` in the install generator is part of the root cause.
5. If the install generator sets up this trap, fix it or document the required configuration.

## Constraints
- Do not break fresh installs (greenfield `db:prepare` / `db:migrate` must still work).
- Preserve multi-database behavior for the pulse DB.
- Minimal, targeted fix — avoid broad schema-loading refactors unless necessary.
- Follow existing Rails Pulse conventions for schema management.

## Expected tests
- Automated test reproducing migrate-on-existing-tables scenario (tables pre-exist, migrate succeeds without error).
- Fresh install path still passes.
- Manual verification: `bundle exec rails db:prepare` then `bundle exec rails db:migrate` completes cleanly when pulse tables already exist.

Mission Control: /missions/15