### PR TITLE
Make upgrades from 0.3.3 safe for existing installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Upgrading from 0.3.3 requires the upgrade generator, a schema migrate, and a one-time route backfill. Exception tracking is **off** for existing installs until you opt in.
+
+### Upgrade from 0.3.3
+
+```bash
+bundle update rails_pulse
+rails generate rails_pulse:upgrade
+rails db:migrate                  # or rails db:migrate:rails_pulse for a separate Pulse database
+rails rails_pulse:migrate_routes  # required — schema migrate alone leaves Action empty
+```
+
+Separate-database hosts: add `schema_dump: false` to the `rails_pulse` entry in `config/database.yml` and delete `db/rails_pulse_structure.sql` if it exists. Then restart all processes together — this release drops `rails_pulse_routes.method`, so mixed old/new code against the new schema will fail tracking and the routes dashboard.
+
+The upgrade generator appends new initializer settings (without rewriting existing values) so you can review them with `git diff`. Exception tracking stays off: it inserts `config.track_exceptions = false`. Set that to `true` after migrating to opt in. New installs get `true` from the generated template. Messages are stored unfiltered; request params use Rails `filter_parameters`.
+
+### Added
+
 - **Route identity is `[controller_action, path]`** — GET `/users` (`users#index`) and POST `/users` (`users#create`) are distinct routes. Each route stores an `http_methods` array; each request records its own HTTP verb. Dynamic paths are normalized at capture time (`/posts/42` → `/posts/:id`).
 - After upgrading, run `rails rails_pulse:migrate_routes` to backfill `controller_action` (from the live router, then from request history), collapse historical literal paths, and merge routes that share the same action (for example GET+POST `/sign_in` → `sessions#new`). The upgrade generator and dashboard warn if this step is skipped.
+- **Exception tracking** — Captures unhandled exceptions from web requests and background jobs, groups them by class and location, and displays full backtraces (first 50 frames) with filtered request params in a new Exceptions tab. Exception messages are stored unfiltered.
+- **`track_exceptions` config option** — Enable or disable exception tracking. Gem default is `false` so existing installs do not start capturing on upgrade. The install template sets `true` for new apps.
+- **`capture_exception_params` config option** — Capture request params alongside each exception occurrence. Params are filtered via Rails' `filter_parameters` config; occurrences with params larger than 10KB after filtering are stored without params. Set to `false` for strict data-minimisation requirements (default: `true`, only used when tracking is on)
+- **Upgrade generator syncs new initializer settings** — Appends keys (and `max_table_records` entries) that the host file does not already mention, without rewriting existing values. Review with `git diff`. `track_exceptions` is inserted as `false`.
+
+### Fixed
+
 - Fixed upgrading when using separate database installation
 - Separate-database installs set `schema_dump: false` so `db:migrate` no longer dumps or loads `db/rails_pulse_structure.sql` (#189)
 - Fixed `assets:precompile` failing on memory-constrained hosts by not registering dashboard assets with the host Sprockets pipeline. Precompile copies the pre-built files into `public/assets` (digested, no compressor) so `config.asset_host` and CDN-only CSP work; development and hosts without a pipeline still use `/rails-pulse-assets/<gem-version>/...`.
 - SQLite `schema.rb` now keeps the partial unique index on unrecognised routes (`WHERE controller_action IS NULL`). A raw `CREATE INDEX` was dumped without the predicate, so `db:schema:load` and parallel tests unique-constrained every path.
-- **Exception tracking** — Captures unhandled exceptions from web requests and background jobs, groups them by class and location, and displays full backtraces (first 50 frames) with filtered request params in a new Exceptions tab. Exception messages are stored unfiltered.
-- **`track_exceptions` config option** — Enable or disable exception tracking (default: `true`)
-- **`capture_exception_params` config option** — Capture request params alongside each exception occurrence. Params are filtered via Rails' `filter_parameters` config; occurrences with params larger than 10KB after filtering are stored without params. Set to `false` for strict data-minimisation requirements (default: `true`)
 
 ## [0.3.3] - 2026-06-23
 
@@ -100,7 +121,8 @@ No changelog entry — see git history.
 
 No changelog entry — see git history.
 
-[Unreleased]: https://github.com/railspulse/rails_pulse/compare/v0.3.0.pre.1...HEAD
+[Unreleased]: https://github.com/railspulse/rails_pulse/compare/v0.3.3...HEAD
+[0.3.3]: https://github.com/railspulse/rails_pulse/compare/v0.3.2...v0.3.3
 [0.3.0.pre.1]: https://github.com/railspulse/rails_pulse/compare/v0.2.7...v0.3.0.pre.1
 [0.2.7]: https://github.com/railspulse/rails_pulse/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/railspulse/rails_pulse/compare/v0.2.5...v0.2.6

--- a/README.md
+++ b/README.md
@@ -60,6 +60,32 @@ RailsPulse::CleanupJob.perform_later  # cron: 0 1 * * *
 
 Your dashboard is now at `http://localhost:3000/rails_pulse`.
 
+## Upgrading
+
+From 0.3.3:
+
+```bash
+bundle update rails_pulse
+rails generate rails_pulse:upgrade
+rails db:migrate                  # or: rails db:migrate:rails_pulse
+rails rails_pulse:migrate_routes  # required — fills Action and merges same-action paths
+```
+
+Restart all processes after migrate. This release changes how routes are stored (`method` moves off the route onto each request), so mixed old/new processes are not supported.
+
+The upgrade generator appends new settings to `config/initializers/rails_pulse.rb` without rewriting what you already set. Review with `git diff` and keep or discard hunks.
+
+Exception tracking is **off** for existing installs. The generator inserts `config.track_exceptions = false`; set it to `true` after migrating to opt in:
+
+```ruby
+config.track_exceptions = true
+config.capture_exception_params = true  # params are filtered via Rails' filter_parameters
+```
+
+Separate-database hosts: set `schema_dump: false` on the `rails_pulse` entry in `config/database.yml` and delete `db/rails_pulse_structure.sql` if that file exists.
+
+If you previously added `rails-pulse.js` / `rails-pulse.css` to `config.assets.precompile`, remove those entries — the gem no longer registers dashboard assets with Sprockets (that re-minify OOMs small hosts). Production deploys that use `config.asset_host` or a CDN-only CSP should run `assets:precompile` so `rails_pulse:install_assets` copies digested files into `public/assets`.
+
 Full install guide: [railspulse.com/documentation/installation](https://railspulse.com/documentation/installation)
 
 Separate database setup: [railspulse.com/documentation/database](https://railspulse.com/documentation/database)

--- a/db/rails_pulse_migrate/20260610000002_change_rails_pulse_routes_to_multi_verb_model.rb
+++ b/db/rails_pulse_migrate/20260610000002_change_rails_pulse_routes_to_multi_verb_model.rb
@@ -15,6 +15,10 @@ class ChangeRailsPulseRoutesToMultiVerbModel < ActiveRecord::Migration[7.0]
         execute("UPDATE rails_pulse_routes SET http_methods = '[\"' || method || '\"]' WHERE http_methods IS NULL AND method IS NOT NULL")
       end
       execute("UPDATE rails_pulse_routes SET http_methods = '[]' WHERE http_methods IS NULL")
+
+      connection.schema_cache.clear! if connection.respond_to?(:schema_cache)
+      http_methods_col = connection.columns(:rails_pulse_routes).find { |c| c.name == "http_methods" }
+      change_column_null :rails_pulse_routes, :http_methods, false if http_methods_col&.null
     end
 
     # Step 3: Add method column to requests so each request records the specific verb used

--- a/docs/adr/0002-exception-capture-web-requests-only.md
+++ b/docs/adr/0002-exception-capture-web-requests-only.md
@@ -6,4 +6,4 @@ The ExceptionSubscriber hooks into `process_action.action_controller` and captur
 
 When `perform_now` raises inside a web request, JobRunCollector records the exception first and the subscriber skips that same exception object so the raise is stored once.
 
-Capture is synchronous on the calling thread (group upsert + occurrence insert). Request performance tracking can run async; exception capture does not yet. That keeps v1 simple and correct under concurrency. The trade-off is added DB latency on failing requests or jobs during an error storm — operators can set `track_exceptions = false` to opt out.
+Capture is synchronous on the calling thread (group upsert + occurrence insert). Request performance tracking can run async; exception capture does not yet. That keeps v1 simple and correct under concurrency. The trade-off is added DB latency on failing requests or jobs during an error storm — the gem default is `track_exceptions = false` so existing installs must opt in. New apps enable it from the generated initializer.

--- a/docs/database_setup.md
+++ b/docs/database_setup.md
@@ -79,7 +79,7 @@ rails rails_pulse:migrate_routes
 
 ```bash
 rails generate rails_pulse:upgrade --database=separate
-rails db:migrate
+rails db:migrate:rails_pulse
 rails rails_pulse:migrate_routes
 ```
 
@@ -106,6 +106,20 @@ rails rails_pulse:migrate_routes
 This backfills `controller_action` from the host router, normalizes historical `/posts/42` paths to `/posts/:id`, merges routes that share the same action, and adds a unique index for unrecognized (404) paths.
 
 If you skip this step, the Action column on the routes page stays empty. The dashboard shows a banner with the same command until a live route still has a blank action.
+
+### Deploy order
+
+This release drops `rails_pulse_routes.method`. Do not run mixed 0.3.3 and new processes against the migrated schema. Typical flow:
+
+1. `bundle update` / deploy the new gem
+2. `rails generate rails_pulse:upgrade`
+3. `rails db:migrate` (or `db:migrate:rails_pulse`)
+4. `rails rails_pulse:migrate_routes`
+5. Restart **all** processes before serving traffic
+
+Release-phase migrate (Heroku, Kamal) is fine if no old processes remain after the release. A rolling restart that leaves 0.3.3 processes running against the new schema will 500 the routes dashboard and silently drop request tracking.
+
+Exception tracking stays **off** for existing installs. After migrating, set `config.track_exceptions = true` to opt in.
 
 ## Troubleshooting
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -96,6 +96,12 @@ separate-database upgrade path before shipping:
 7. Restore the initializer: comment `connects_to` back out and delete the temporary
    SQLite file.
 
+Also for this release: bump `RailsPulse::VERSION` (0.3.3 is already on RubyGems). Route
+identity is a breaking schema change — prefer a minor bump (0.4.0). After
+`assets:precompile`, confirm logs include `[RailsPulse] Installed N dashboard assets`.
+If any CDN caches `/rails-pulse-assets/<version>/...` as immutable, the version bump
+is what busts that cache.
+
 ### 2. Update Version
 
 ```bash

--- a/lib/generators/rails_pulse/templates/rails_pulse.rb
+++ b/lib/generators/rails_pulse/templates/rails_pulse.rb
@@ -126,8 +126,11 @@ RailsPulse.configure do |config|
   #
   # Capture runs synchronously on the calling thread (upsert + insert). That keeps
   # the implementation simple for v1; under an error storm it adds DB latency to
-  # failing requests and jobs. Disable with track_exceptions = false if that cost
-  # is unacceptable.
+  # failing requests and jobs. Set track_exceptions = false to disable.
+  #
+  # The gem default is false so existing installs do not start capturing on
+  # upgrade. New apps get true from this template; the upgrade generator
+  # inserts false into existing initializers.
   #
   # Backtraces store the first 50 frames. Exception messages are stored as raised
   # (not filtered); request params are filtered via Rails' filter_parameters.

--- a/lib/generators/rails_pulse/upgrade_generator.rb
+++ b/lib/generators/rails_pulse/upgrade_generator.rb
@@ -1,5 +1,6 @@
 require_relative "base_methods"
 require_relative "schema_parser"
+require_relative "../../rails_pulse/installers/config_updater"
 
 module RailsPulse
   module Generators
@@ -21,9 +22,10 @@ module RailsPulse
 
         case @database_type
         when :single
-          upgrade_installation(migration_dir: "db/migrate", next_steps: single_db_next_steps)
+          upgrade_installation(migration_dir: "db/migrate", migrate_command: "rails db:migrate")
         when :separate
-          upgrade_installation(migration_dir: "db/rails_pulse_migrate", next_steps: separate_db_next_steps)
+          warn_if_missing_schema_dump_false
+          upgrade_installation(migration_dir: "db/rails_pulse_migrate", migrate_command: "rails db:migrate:rails_pulse")
         when :schema_only
           offer_conversion_to_migrations
         when :not_installed
@@ -98,31 +100,35 @@ module RailsPulse
       # Key is a substring of the migration filename (without timestamp).
       FEATURE_NOTICES = {
         "create_rails_pulse_exceptions" => <<~NOTICE.rstrip
-          Exception tracking (new)
+          Exception tracking (opt-in)
 
-          This upgrade adds exception tracking. After you migrate, Rails Pulse will
-          capture unhandled exceptions from web requests and background jobs and
-          show them in an Exceptions tab. Two new tables will be created:
+          This upgrade adds exception tables. Capture stays off for existing
+          installs until you opt in. After migrating, set the following in
+          config/initializers/rails_pulse.rb (the upgrade generator inserts
+          it as false — review with git diff) and restart:
+
+            config.track_exceptions = true
+
+          New installs enable this in the generated initializer. Messages are
+          stored unfiltered; request params use Rails filter_parameters.
+
+          Two new tables will be created:
             - rails_pulse_exception_groups
             - rails_pulse_exception_occurrences
 
-          Exception tracking is enabled by default. To disable capture and hide the
-          Exceptions tab, set in config/initializers/rails_pulse.rb:
-
-            config.track_exceptions = false
-
-          If you do not want the tables at all, delete the copied
-          *_create_rails_pulse_exceptions.rb migration before running db:migrate,
-          and set config.track_exceptions = false. (A later upgrade will copy the
-          migration again unless that file is still present in your migrate folder.)
+          To skip the tables entirely, delete the copied
+          *_create_rails_pulse_exceptions.rb migration before db:migrate.
+          (A later upgrade will copy it again unless that file remains in
+          your migrate folder.)
         NOTICE
       }.freeze
 
       # Shared upgrade logic for both single and separate database setups
-      def upgrade_installation(migration_dir:, next_steps:)
+      def upgrade_installation(migration_dir:, migrate_command:)
         # Refresh the schema file so fresh databases (test, CI) built from
         # db/rails_pulse_schema.rb include all current columns and tables.
         copy_file "db/rails_pulse_schema.rb", "db/rails_pulse_schema.rb"
+        sync_initializer
 
         gem_migrations = get_gem_migrations
         existing_migrations = get_user_migrations(migration_dir)
@@ -137,11 +143,11 @@ module RailsPulse
 
           say "\nMigrations copied successfully!", :green
           announce_new_features(new_migrations)
-          say_route_backfill_warning if requires_route_backfill?(new_migrations)
-          say "\nNext steps:", :green
-          next_steps.each { |step| say step }
+          include_route_backfill = requires_route_backfill?(new_migrations)
+          say_route_backfill_warning if include_route_backfill
+          say_next_steps(migrate_command, include_route_backfill: include_route_backfill)
         else
-          upgrade_with_missing_columns(migration_dir: migration_dir, next_steps: next_steps)
+          upgrade_with_missing_columns(migration_dir: migration_dir, migrate_command: migrate_command)
         end
       end
 
@@ -159,11 +165,15 @@ module RailsPulse
         say ("=" * 72) + "\n", :yellow
       end
 
-      def upgrade_with_missing_columns(migration_dir:, next_steps:)
+      def upgrade_with_missing_columns(migration_dir:, migrate_command:)
         missing_columns = detect_missing_columns
 
         if missing_columns.empty?
-          say "Rails Pulse is up to date! No migration needed.", :green
+          if @initializer_updated
+            say "Schema is up to date. Review initializer changes with git diff.", :green
+          else
+            say "Rails Pulse is up to date! No migration needed.", :green
+          end
           return
         end
 
@@ -181,9 +191,9 @@ module RailsPulse
 
         say "\nUpgrade migration created successfully!", :green
         missing_names = missing_columns.keys.map(&:to_s)
-        say_route_backfill_warning if missing_names.intersect?(%w[controller_action http_methods])
-        say "\nNext steps:", :green
-        next_steps.each { |step| say step }
+        include_route_backfill = missing_names.intersect?(%w[controller_action http_methods])
+        say_route_backfill_warning if include_route_backfill
+        say_next_steps(migrate_command, include_route_backfill: include_route_backfill)
         say "\nThis migration will add: #{missing_columns.keys.join(', ')}\n"
       end
 
@@ -205,21 +215,62 @@ module RailsPulse
         say "Skipping this leaves GET/POST on the same path unmerged in the dashboard.", :yellow
       end
 
-      def single_db_next_steps
-        [
-          "1. Run: rails db:migrate",
-          "2. Run: rails rails_pulse:migrate_routes",
-          "3. Restart your Rails server"
-        ]
+      def say_next_steps(migrate_command, include_route_backfill:)
+        n = 1
+        say "\nNext steps:", :green
+        say "#{n}. Run: #{migrate_command}"
+        n += 1
+        if include_route_backfill
+          say "#{n}. Run: rails rails_pulse:migrate_routes"
+          n += 1
+        end
+        if @initializer_updated
+          say "#{n}. Review config/initializers/rails_pulse.rb with git diff"
+          n += 1
+        end
+        say "#{n}. Restart your Rails server"
       end
 
-      def separate_db_next_steps
-        [
-          "1. Run migrations for the rails_pulse database:",
-          "   rails db:migrate:rails_pulse",
-          "2. Run: rails rails_pulse:migrate_routes",
-          "3. Restart your Rails server"
-        ]
+      def sync_initializer
+        path = File.join(root_path, "config/initializers/rails_pulse.rb")
+        result = RailsPulse::Installers::ConfigUpdater.update(
+          destination: path,
+          source: File.join(self.class.source_root, "rails_pulse.rb")
+        )
+        @initializer_updated = result[:status] == :updated
+        return unless @initializer_updated
+
+        say "\nUpdated config/initializers/rails_pulse.rb with new settings:", :blue
+        result[:keys].each { |key| say "  - config.#{key}", :blue }
+        result[:hash_keys].each { |key| say "  - #{key}", :blue }
+        say "Review with git diff and keep or discard hunks.", :green
+      end
+
+      def warn_if_missing_schema_dump_false
+        return unless separate_database_missing_schema_dump_false?
+
+        say "\nIMPORTANT: Add schema_dump: false to the rails_pulse entry in", :yellow
+        say "config/database.yml. Without it, Rails may dump or load", :yellow
+        say "db/rails_pulse_structure.sql and db:migrate can fail with", :yellow
+        say "\"relation already exists\". Delete that structure file if present.", :yellow
+      end
+
+      def separate_database_missing_schema_dump_false?
+        config_path = File.join(root_path, "config/database.yml")
+        return false unless File.exist?(config_path)
+
+        require "yaml"
+        require "erb"
+        yaml_content = ERB.new(File.read(config_path)).result
+        db_config = YAML.safe_load(yaml_content, aliases: true)
+        pulse_entries = db_config.values.filter_map do |env|
+          env["rails_pulse"] if env.is_a?(Hash)
+        end
+        return false if pulse_entries.empty?
+
+        pulse_entries.any? { |entry| !entry.is_a?(Hash) || entry["schema_dump"] != false }
+      rescue
+        false
       end
 
       def offer_conversion_to_migrations

--- a/lib/rails_pulse/cleanup_service.rb
+++ b/lib/rails_pulse/cleanup_service.rb
@@ -47,8 +47,10 @@ module RailsPulse
       @stats[:time_based][:queries]               = cleanup_queries_by_time(cutoff_time)
       @stats[:time_based][:routes]                = cleanup_routes_by_time(cutoff_time)
       @stats[:time_based][:jobs]                  = cleanup_jobs_by_time(cutoff_time)
-      @stats[:time_based][:exception_occurrences] = cleanup_exception_occurrences_by_time(cutoff_time)
-      @stats[:time_based][:exception_groups]      = cleanup_orphaned_exception_groups
+      if exception_tables_exist?
+        @stats[:time_based][:exception_occurrences] = cleanup_exception_occurrences_by_time(cutoff_time)
+        @stats[:time_based][:exception_groups]      = cleanup_orphaned_exception_groups
+      end
     end
 
     def perform_count_based_cleanup
@@ -71,9 +73,11 @@ module RailsPulse
       @stats[:count_based][:queries]               = cleanup_queries_by_count
       @stats[:count_based][:routes]                = cleanup_routes_by_count
       @stats[:count_based][:jobs]                  = cleanup_jobs_by_count
-      @stats[:count_based][:exception_occurrences] = cleanup_exception_occurrences_by_count
-      @stats[:count_based][:exception_groups]      = cleanup_exception_groups_by_count
-      @stats[:count_based][:orphaned_exception_groups] = cleanup_orphaned_exception_groups
+      if exception_tables_exist?
+        @stats[:count_based][:exception_occurrences] = cleanup_exception_occurrences_by_count
+        @stats[:count_based][:exception_groups]      = cleanup_exception_groups_by_count
+        @stats[:count_based][:orphaned_exception_groups] = cleanup_orphaned_exception_groups
+      end
     end
 
     # Shared helper: delete oldest records beyond a configured max count
@@ -191,6 +195,12 @@ module RailsPulse
         "id NOT IN (SELECT job_id FROM rails_pulse_job_runs WHERE job_id IS NOT NULL)"
       )
       cleanup_by_count(RailsPulse::Job, :rails_pulse_jobs, order_column: :created_at, scope: scope)
+    end
+
+    def exception_tables_exist?
+      connection = RailsPulse::ApplicationRecord.connection
+      connection.table_exists?(:rails_pulse_exception_groups) &&
+        connection.table_exists?(:rails_pulse_exception_occurrences)
     end
 
     def cleanup_exception_occurrences_by_time(cutoff_time)

--- a/lib/rails_pulse/configuration.rb
+++ b/lib/rails_pulse/configuration.rb
@@ -59,7 +59,10 @@ module RailsPulse
       @ignored_queues = []
       @track_assets = false
       @track_jobs = false
-      @track_exceptions = true
+      # Off unless the host initializer opts in. The install template sets true
+      # for new apps; existing 0.3.3 initializers omit this key, so a true
+      # default would start capturing exception messages (unfiltered) on upgrade.
+      @track_exceptions = false
       @capture_exception_params = true
       @custom_asset_patterns = []
       @mount_path = nil

--- a/lib/rails_pulse/engine.rb
+++ b/lib/rails_pulse/engine.rb
@@ -41,6 +41,7 @@ module RailsPulse
   module Installers
     autoload :MigrationInstaller, File.expand_path("installers/migration_installer", __dir__)
     autoload :ConfigInstaller, File.expand_path("installers/config_installer", __dir__)
+    autoload :ConfigUpdater, File.expand_path("installers/config_updater", __dir__)
   end
 
   # Stats reporting services

--- a/lib/rails_pulse/installers/config_updater.rb
+++ b/lib/rails_pulse/installers/config_updater.rb
@@ -1,0 +1,202 @@
+module RailsPulse
+  module Installers
+    # Inserts settings from the install template that the host initializer does
+    # not already mention. Existing lines are never rewritten, so `git diff` is
+    # the review: keep or discard hunks. Values that differ between a new
+    # install and an upgrade (today: track_exceptions) use the gem default.
+    class ConfigUpdater
+      ASSIGNMENT = /\A\s*(#\s*)?config\.(\w+)\s*=/.freeze
+      HASH_ENTRY = /\A\s*([a-z_][a-z0-9_]*):/.freeze
+
+      UPGRADE_VALUE_OVERRIDES = {
+        "track_exceptions" => "false"
+      }.freeze
+
+      BANNER = <<~RUBY.gsub(/^/, "  ")
+        # ====================================================================================================
+        #                              ADDED BY rails generate rails_pulse:upgrade
+        # ====================================================================================================
+        # New settings from this gem version. Existing values above were not changed.
+        # Review with git diff and keep or discard hunks as you like.
+
+      RUBY
+
+      attr_reader :output, :source, :destination
+
+      def self.update(destination:, source: nil, output: $stdout)
+        new(destination: destination, source: source, output: output).update
+      end
+
+      def self.template_path
+        File.expand_path("../../../../lib/generators/rails_pulse/templates/rails_pulse.rb", __FILE__)
+      end
+
+      def initialize(destination:, source: nil, output: $stdout)
+        @destination = destination
+        @source = source || self.class.template_path
+        @output = output
+      end
+
+      def update
+        return { status: :missing, keys: [], hash_keys: [] } unless File.exist?(destination)
+
+        host = File.read(destination)
+        missing_keys = template_settings.map { |setting| setting[:key] } - mentioned_keys(host)
+        hash_keys = missing_hash_entries(host, missing_keys)
+
+        return { status: :unchanged, keys: [], hash_keys: [] } if missing_keys.empty? && hash_keys.empty?
+
+        updated = host
+        updated = inject_hash_entries(updated, hash_keys) if hash_keys.any?
+        updated = append_settings(updated, missing_keys) if missing_keys.any?
+        File.write(destination, updated)
+
+        { status: :updated, keys: missing_keys, hash_keys: hash_keys.map { |entry| entry[:name] } }
+      end
+
+      private
+
+      def template_settings
+        @template_settings ||= parse_settings(File.read(source))
+      end
+
+      def parse_settings(content)
+        settings = []
+        comments = []
+        lines = content.lines
+        index = 0
+
+        while index < lines.size
+          line = lines[index]
+
+          if line.match?(ASSIGNMENT)
+            key = line[ASSIGNMENT, 2]
+            assignment, index = read_multiline(lines, index)
+            unless settings.any? { |setting| setting[:key] == key }
+              settings << { key: key, lines: comments + assignment }
+            end
+            comments = []
+          elsif preamble?(line)
+            comments = []
+            index += 1
+          else
+            comments << line
+            index += 1
+          end
+        end
+
+        settings
+      end
+
+      def preamble?(line)
+        line.match?(/\A\s*(RailsPulse\.configure|end)\b/) || line.match?(/\A\s*do\s*\|config\|/)
+      end
+
+      def read_multiline(lines, index)
+        collected = [ lines[index] ]
+        depth = nest_delta(lines[index])
+        index += 1
+
+        while index < lines.size && depth.positive?
+          collected << lines[index]
+          depth += nest_delta(lines[index])
+          index += 1
+        end
+
+        [ collected, index ]
+      end
+
+      def nest_delta(line)
+        code = line.sub(/#.*\z/, "")
+        code.count("{") - code.count("}") + code.count("[") - code.count("]")
+      end
+
+      def mentioned_keys(content)
+        content.scan(/config\.(\w+)/).flatten.uniq
+      end
+
+      def missing_hash_entries(host, missing_keys)
+        template_settings.filter_map do |setting|
+          next if missing_keys.include?(setting[:key])
+          next unless host.match?(/^\s*config\.#{Regexp.escape(setting[:key])}\s*=\s*\{/)
+
+          setting[:lines].filter_map do |line|
+            name = line[HASH_ENTRY, 1]
+            next unless name
+            next if host.match?(/^\s*#{Regexp.escape(name)}:/)
+
+            { setting: setting[:key], name: name, line: line }
+          end
+        end.flatten
+      end
+
+      def inject_hash_entries(content, entries)
+        entries.group_by { |entry| entry[:setting] }.reduce(content) do |text, (setting, grouped)|
+          pattern = /(^\s*config\.#{Regexp.escape(setting)}\s*=\s*\{)(.*?)(\n\s*\})/m
+          text.sub(pattern) do
+            opening, body, closing = Regexp.last_match[1], Regexp.last_match[2], Regexp.last_match[3]
+            "#{opening}#{body_with_comma(body)}\n#{grouped.map { |entry| entry[:line].rstrip }.join("\n")}#{closing}"
+          end
+        end
+      end
+
+      def body_with_comma(body)
+        lines = body.lines
+        index = lines.rindex { |line| line.strip != "" }
+        return body unless index
+
+        working = lines[index].chomp
+        return body if working.match?(/,\s*(#.*)?\z/)
+
+        working = if working.include?("#")
+          working.sub(/\s+#/, ", #")
+        else
+          "#{working},"
+        end
+        lines[index] = "#{working}\n"
+        lines.join
+      end
+
+      def append_settings(content, keys)
+        blocks = keys.filter_map do |key|
+          setting = template_settings.find { |candidate| candidate[:key] == key }
+          next unless setting
+
+          apply_overrides(setting[:lines], key).join
+        end
+        return content if blocks.empty?
+
+        insertion = BANNER + blocks.join("\n").gsub(/\n+\z/, "\n")
+        insert_before_configure_end(content, insertion)
+      end
+
+      def insert_before_configure_end(content, insertion)
+        lines = content.lines
+        start_index = lines.index { |line| line.match?(/^\s*RailsPulse\.configure\b/) }
+
+        unless start_index
+          return content + "\nRailsPulse.configure do |config|\n#{insertion}end\n"
+        end
+
+        indent = lines[start_index][/\A\s*/]
+        end_index = ((start_index + 1)...lines.size).find do |index|
+          lines[index].match?(/\A#{Regexp.escape(indent)}end\b/)
+        end
+
+        unless end_index
+          return content.sub(/\nend\s*\z/, "\n\n#{insertion}end\n")
+        end
+
+        (lines[0...end_index] + [ "\n#{insertion}" ] + lines[end_index..]).join
+      end
+
+      def apply_overrides(lines, key)
+        return lines unless UPGRADE_VALUE_OVERRIDES.key?(key)
+
+        lines.map do |line|
+          line.sub(/config\.#{Regexp.escape(key)}\s*=\s*.*/, "config.#{key} = #{UPGRADE_VALUE_OVERRIDES[key]}")
+        end
+      end
+    end
+  end
+end

--- a/rails_pulse.gemspec
+++ b/rails_pulse.gemspec
@@ -29,8 +29,10 @@ Gem::Specification.new do |spec|
   spec.executables = [ "rails_pulse_server" ]
 
   spec.post_install_message = <<~MSG
-    Rails Pulse #{RailsPulse::VERSION} installed. If upgrading, run:
-      rails generate rails_pulse:upgrade && rails db:migrate
+    Rails Pulse #{RailsPulse::VERSION} installed. If upgrading from 0.3.3, run:
+      rails generate rails_pulse:upgrade
+      rails db:migrate                  # or rails db:migrate:rails_pulse
+      rails rails_pulse:migrate_routes  # required for this release
   MSG
 
   spec.add_dependency "rails", ">= 7.1.0", "< 9.0.0"

--- a/test/controllers/rails_pulse/exceptions_controller_test.rb
+++ b/test/controllers/rails_pulse/exceptions_controller_test.rb
@@ -176,9 +176,9 @@ class RailsPulse::ExceptionsControllerTest < ActionDispatch::IntegrationTest
     assert_nil assigns(:latest_occurrence)
   end
 
-  test "exceptions routes are accessible when track_exceptions is true (default)" do
+  test "exceptions routes are accessible when track_exceptions is enabled" do
     assert RailsPulse.configuration.track_exceptions,
-      "track_exceptions must be true for this test to be meaningful"
+      "dummy initializer must enable track_exceptions for this test to be meaningful"
 
     get rails_pulse.exceptions_path
 

--- a/test/dummy/config/initializers/rails_pulse.rb
+++ b/test/dummy/config/initializers/rails_pulse.rb
@@ -140,6 +140,11 @@ RailsPulse.configure do |config|
   # Enable or disable background job tracking
   config.track_jobs = true
 
+  # Enable exception tracking in the dummy app (gem default is false so existing
+  # host apps do not start capturing on upgrade without an explicit opt-in).
+  config.track_exceptions = true
+  config.capture_exception_params = true
+
   # Thresholds for job execution times (in milliseconds)
   config.job_thresholds = {
     slow:      5_000,   # 5 seconds

--- a/test/dummy/db/migrate/20260610000002_change_rails_pulse_routes_to_multi_verb_model.rb
+++ b/test/dummy/db/migrate/20260610000002_change_rails_pulse_routes_to_multi_verb_model.rb
@@ -15,6 +15,10 @@ class ChangeRailsPulseRoutesToMultiVerbModel < ActiveRecord::Migration[7.0]
         execute("UPDATE rails_pulse_routes SET http_methods = '[\"' || method || '\"]' WHERE http_methods IS NULL AND method IS NOT NULL")
       end
       execute("UPDATE rails_pulse_routes SET http_methods = '[]' WHERE http_methods IS NULL")
+
+      connection.schema_cache.clear! if connection.respond_to?(:schema_cache)
+      http_methods_col = connection.columns(:rails_pulse_routes).find { |c| c.name == "http_methods" }
+      change_column_null :rails_pulse_routes, :http_methods, false if http_methods_col&.null
     end
 
     # Step 3: Add method column to requests so each request records the specific verb used

--- a/test/generators/upgrade_generator_test.rb
+++ b/test/generators/upgrade_generator_test.rb
@@ -112,7 +112,7 @@ test "detects separate database setup from database.yml" do
 
     assert_match(/Found 1 new migration/, output)
     assert_file "db/migrate/20251019000000_add_new_feature.rb"
-    assert_match(/rails rails_pulse:migrate_routes/, output)
+    assert_no_match(/rails rails_pulse:migrate_routes/, output)
     assert_no_match(/IMPORTANT: This upgrade changes how routes are identified/, output)
   end
 
@@ -173,12 +173,46 @@ test "detects separate database setup from database.yml" do
       run_generator([], {})
     end
 
-    assert_match(/Exception tracking \(new\)/, output)
+    assert_match(/Exception tracking \(opt-in\)/, output)
     assert_match(/rails_pulse_exception_groups/, output)
     assert_match(/rails_pulse_exception_occurrences/, output)
-    assert_match(/config\.track_exceptions = false/, output)
+    assert_match(/config\.track_exceptions = true/, output)
     assert_match(/delete the copied/, output)
     assert_file "db/migrate/20260506000001_create_rails_pulse_exceptions.rb"
+  end
+
+  test "appends missing initializer settings and preserves existing values" do
+    File.write(File.join(destination_root, "config/database.yml"), single_database_yml)
+    FileUtils.mkdir_p(File.join(destination_root, "config/initializers"))
+    File.write(
+      File.join(destination_root, "config/initializers/rails_pulse.rb"),
+      <<~RUBY
+        RailsPulse.configure do |config|
+          config.enabled = true
+          config.tags = [ "keep-me" ]
+          config.max_table_records = {
+            rails_pulse_requests: 42,
+            rails_pulse_queries: 500
+          }
+        end
+      RUBY
+    )
+    create_gem_migration("add_new_feature", "20251019000000")
+
+    output = mock_tables_exist do
+      run_generator([], {})
+    end
+
+    assert_match(/Updated config\/initializers\/rails_pulse\.rb/, output)
+    assert_match(/config\.track_exceptions/, output)
+    assert_match(/git diff/, output)
+    assert_file "config/initializers/rails_pulse.rb" do |content|
+      assert_match(/config\.tags = \[ "keep-me" \]/, content)
+      assert_match(/rails_pulse_requests: 42/, content)
+      assert_match(/config\.track_exceptions = false/, content)
+      assert_match(/config\.capture_exception_params = true/, content)
+      assert_match(/rails_pulse_exception_occurrences/, content)
+    end
   end
 
   test "does not print exception tracking notice when exceptions migration already present" do
@@ -213,7 +247,30 @@ test "separate database upgrade copies migrations to rails_pulse_migrate" do
     assert_match(/Found 1 new migration/, output)
     assert_file "db/rails_pulse_migrate/20251019000000_add_new_feature.rb"
     assert_match(/rails db:migrate:rails_pulse/, output)
-    assert_match(/rails rails_pulse:migrate_routes/, output)
+    assert_no_match(/rails rails_pulse:migrate_routes/, output)
+  end
+
+  test "separate database upgrade warns when schema_dump is not false" do
+    File.write(File.join(destination_root, "config/database.yml"), separate_database_yml_without_schema_dump)
+    create_gem_migration("add_new_feature", "20251019000000")
+
+    output = mock_tables_exist do
+      run_generator([], { database: "separate" })
+    end
+
+    assert_match(/Add schema_dump: false/, output)
+    assert_match(/rails_pulse_structure\.sql/, output)
+  end
+
+  test "separate database upgrade does not warn when schema_dump is false" do
+    File.write(File.join(destination_root, "config/database.yml"), separate_database_yml)
+    create_gem_migration("add_new_feature", "20251019000000")
+
+    output = mock_tables_exist do
+      run_generator([], { database: "separate" })
+    end
+
+    assert_no_match(/Add schema_dump: false/, output)
   end
 
   # Missing Column Detection Tests

--- a/test/lib/rails_pulse/cleanup_service_test.rb
+++ b/test/lib/rails_pulse/cleanup_service_test.rb
@@ -57,6 +57,12 @@ module RailsPulse
       assert_nil result
     end
 
+    test "perform succeeds when exception tables are missing" do
+      CleanupService.any_instance.stubs(:exception_tables_exist?).returns(false)
+
+      assert_nothing_raised { CleanupService.perform }
+    end
+
     # Time-based Cleanup Tests
 
     test "time-based cleanup deletes operations older than retention period" do

--- a/test/lib/rails_pulse/configuration_test.rb
+++ b/test/lib/rails_pulse/configuration_test.rb
@@ -73,6 +73,7 @@ module RailsPulse
       expected_tables = %i[
         rails_pulse_operations rails_pulse_requests rails_pulse_job_runs
         rails_pulse_queries rails_pulse_routes rails_pulse_jobs
+        rails_pulse_exception_occurrences rails_pulse_exception_groups
       ]
 
       expected_tables.each do |key|
@@ -198,10 +199,10 @@ module RailsPulse
       end
     end
 
-    test "track_exceptions defaults to true" do
+    test "track_exceptions defaults to false" do
       config = Configuration.new
 
-      assert config.track_exceptions
+      refute config.track_exceptions
     end
 
     test "capture_exception_params defaults to true" do

--- a/test/lib/rails_pulse/installers/config_updater_test.rb
+++ b/test/lib/rails_pulse/installers/config_updater_test.rb
@@ -1,0 +1,251 @@
+require "test_helper"
+require "rails_pulse/installers/config_updater"
+
+module RailsPulse
+  module Installers
+    class ConfigUpdaterTest < ActiveSupport::TestCase
+      def setup
+        @dir = Dir.mktmpdir("rails_pulse_config_updater")
+        @template = File.join(@dir, "template.rb")
+        @destination = File.join(@dir, "rails_pulse.rb")
+        @output = StringIO.new
+      end
+
+      def teardown
+        FileUtils.remove_entry(@dir)
+      end
+
+      # Insert Tests
+
+      test "inserts missing settings without rewriting existing values" do
+        write_template <<~RUBY
+          RailsPulse.configure do |config|
+            config.enabled = true
+
+            # Exception tracking
+            config.track_exceptions = true
+            config.capture_exception_params = true
+          end
+        RUBY
+        write_host <<~RUBY
+          RailsPulse.configure do |config|
+            config.enabled = true
+            config.tags = [ "custom" ]
+          end
+        RUBY
+
+        result = update_config
+
+        assert_equal :updated, result[:status]
+        assert_equal %w[track_exceptions capture_exception_params], result[:keys]
+        host = File.read(@destination)
+
+        assert_includes host, 'config.tags = [ "custom" ]'
+        assert_includes host, "config.enabled = true"
+        assert_includes host, "config.track_exceptions = false"
+        assert_includes host, "config.capture_exception_params = true"
+        assert_includes host, "ADDED BY rails generate rails_pulse:upgrade"
+        assert_valid_ruby host
+      end
+
+      test "uses gem default for track_exceptions instead of the install template value" do
+        write_template <<~RUBY
+          RailsPulse.configure do |config|
+            config.track_exceptions = true
+          end
+        RUBY
+        write_host <<~RUBY
+          RailsPulse.configure do |config|
+            config.enabled = true
+          end
+        RUBY
+
+        update_config
+
+        assert_includes File.read(@destination), "config.track_exceptions = false"
+        refute_includes File.read(@destination), "config.track_exceptions = true"
+      end
+
+      test "is a no-op when every template setting is already mentioned" do
+        write_template <<~RUBY
+          RailsPulse.configure do |config|
+            config.enabled = true
+            config.track_exceptions = true
+          end
+        RUBY
+        original = <<~RUBY
+          RailsPulse.configure do |config|
+            config.enabled = false
+            # config.track_exceptions = true
+          end
+        RUBY
+        write_host original
+
+        result = update_config
+
+        assert_equal :unchanged, result[:status]
+        assert_equal original, File.read(@destination)
+      end
+
+      test "skips when the initializer is missing" do
+        write_template "RailsPulse.configure do |config|\nend\n"
+
+        result = update_config
+
+        assert_equal :missing, result[:status]
+        refute_path_exists @destination
+      end
+
+      test "does not duplicate settings when run twice" do
+        write_template <<~RUBY
+          RailsPulse.configure do |config|
+            config.track_exceptions = true
+          end
+        RUBY
+        write_host <<~RUBY
+          RailsPulse.configure do |config|
+            config.enabled = true
+          end
+        RUBY
+
+        update_config
+        result = update_config
+
+        assert_equal :unchanged, result[:status]
+        assert_equal 1, File.read(@destination).scan("config.track_exceptions").size
+      end
+
+      test "inserts inside RailsPulse.configure when another end follows it" do
+        write_template <<~RUBY
+          RailsPulse.configure do |config|
+            config.track_exceptions = true
+          end
+        RUBY
+        write_host <<~RUBY
+          RailsPulse.configure do |config|
+            config.enabled = true
+          end
+
+          Rails.application.config.to_prepare do
+            RailsPulse::ApplicationController.skip_after_action :intercom_rails_auto_include, raise: false
+          end
+        RUBY
+
+        update_config
+        host = File.read(@destination)
+        configure, trailing = host.split(/Rails\.application\.config\.to_prepare/, 2)
+
+        assert_includes configure, "config.track_exceptions = false"
+        refute_includes trailing, "config.track_exceptions"
+        assert_includes trailing, "skip_after_action :intercom_rails_auto_include"
+        assert_valid_ruby host
+      end
+
+      # Hash Entry Tests
+
+      test "inserts missing max_table_records keys and preserves existing limits" do
+        write_template <<~RUBY
+          RailsPulse.configure do |config|
+            config.max_table_records = {
+              rails_pulse_requests: 10000,
+              rails_pulse_exception_occurrences: 50000,
+              rails_pulse_exception_groups: 10000
+            }
+          end
+        RUBY
+        write_host <<~RUBY
+          RailsPulse.configure do |config|
+            config.max_table_records = {
+              rails_pulse_requests: 42,
+              rails_pulse_queries: 500
+            }
+          end
+        RUBY
+
+        result = update_config
+
+        assert_equal :updated, result[:status]
+        assert_empty result[:keys]
+        assert_equal %w[rails_pulse_exception_occurrences rails_pulse_exception_groups], result[:hash_keys]
+        host = File.read(@destination)
+
+        assert_includes host, "rails_pulse_requests: 42"
+        assert_includes host, "rails_pulse_queries: 500,"
+        assert_includes host, "rails_pulse_exception_occurrences: 50000"
+        assert_includes host, "rails_pulse_exception_groups: 10000"
+        assert_valid_ruby host
+      end
+
+      # Install Template Tests
+
+      test "adds exception settings from the real install template into a 0.3.3 initializer" do
+        write_host File.read(v033_initializer_path).sub(
+          'config.tags = [ "ignored", "critical", "experimental" ]',
+          'config.tags = [ "keep-me" ]'
+        )
+
+        result = RailsPulse::Installers::ConfigUpdater.update(
+          destination: @destination,
+          output: @output
+        )
+
+        assert_equal :updated, result[:status]
+        assert_includes result[:keys], "track_exceptions"
+        assert_includes result[:keys], "capture_exception_params"
+        host = File.read(@destination)
+
+        assert_includes host, 'config.tags = [ "keep-me" ]'
+        assert_includes host, "config.track_exceptions = false"
+        assert_includes host, "config.capture_exception_params = true"
+        assert_includes host, "rails_pulse_exception_occurrences"
+        assert_includes host, "rails_pulse_exception_groups"
+        assert_valid_ruby host
+      end
+
+      private
+
+      def write_template(content)
+        File.write(@template, content)
+      end
+
+      def write_host(content)
+        File.write(@destination, content)
+      end
+
+      def update_config
+        ConfigUpdater.update(destination: @destination, source: @template, output: @output)
+      end
+
+      def v033_initializer_path
+        path = File.join(@dir, "v0_3_3.rb")
+        File.write(path, v033_initializer)
+        path
+      end
+
+      def assert_valid_ruby(source)
+        RubyVM::InstructionSequence.compile(source)
+      end
+
+      def v033_initializer
+        # Shape of the 0.3.3 generated initializer: no exception settings, no
+        # exception table limits, and a typical max_table_records hash.
+        <<~RUBY
+          RailsPulse.configure do |config|
+            config.enabled = true
+            config.track_assets = false
+            config.tags = [ "ignored", "critical", "experimental" ]
+            config.track_jobs = false
+            config.archiving_enabled = true
+            config.full_retention_period = 2.weeks
+            config.max_table_records = {
+              rails_pulse_requests: 10000,
+              rails_pulse_operations: 50000,
+              rails_pulse_routes: 1000,
+              rails_pulse_queries: 500
+            }
+          end
+        RUBY
+      end
+    end
+  end
+end

--- a/test/migrations/upgrade_migration_test.rb
+++ b/test/migrations/upgrade_migration_test.rb
@@ -55,7 +55,85 @@ class UpgradeMigrationTest < ActiveSupport::TestCase
     assert col.null, "controller_action should be nullable"
   end
 
-  test "upgrade from v0.2.7 converts routes to multi-verb model" do
+    test "upgrade from v0.3.3 converts routes to multi-verb model" do
+      load_baseline(RailsPulse::TestSchemas::V033)
+      run_all_migrations
+
+      assert @conn.column_exists?(:rails_pulse_routes, :http_methods), "http_methods missing on routes"
+      assert_not @conn.column_exists?(:rails_pulse_routes, :method), "old method column should be removed"
+      assert @conn.column_exists?(:rails_pulse_requests, :method), "method column missing on requests"
+      assert @conn.column_exists?(:rails_pulse_routes, :controller_action)
+
+      http_methods_col = @conn.columns(:rails_pulse_routes).find { |c| c.name == "http_methods" }
+
+      assert_not http_methods_col.null, "http_methods should be NOT NULL after upgrade"
+    end
+
+    test "upgrade from v0.3.3 creates exception tables and keeps existing 0.3.3 columns" do
+      load_baseline(RailsPulse::TestSchemas::V033)
+      run_all_migrations
+
+      assert @conn.table_exists?(:rails_pulse_exception_groups)
+      assert @conn.table_exists?(:rails_pulse_exception_occurrences)
+      assert @conn.column_exists?(:rails_pulse_exception_groups, :location)
+      assert @conn.table_exists?(:rails_pulse_deployments)
+      assert @conn.column_exists?(:rails_pulse_operations, :actual_sql)
+    end
+
+    test "upgrade from v0.3.3 keeps GET and POST on the same path as separate routes" do
+      load_baseline(RailsPulse::TestSchemas::V033)
+
+      now = Time.current.iso8601(6)
+      @conn.execute(<<~SQL)
+        INSERT INTO rails_pulse_routes (method, path, created_at, updated_at)
+        VALUES ('GET', '/users', '#{now}', '#{now}')
+      SQL
+      get_id = @conn.select_value("SELECT id FROM rails_pulse_routes WHERE method = 'GET' AND path = '/users'")
+
+      @conn.execute(<<~SQL)
+        INSERT INTO rails_pulse_routes (method, path, created_at, updated_at)
+        VALUES ('POST', '/users', '#{now}', '#{now}')
+      SQL
+      post_id = @conn.select_value("SELECT id FROM rails_pulse_routes WHERE method = 'POST' AND path = '/users'")
+
+      is_error_value = @conn.adapter_name.downcase == "postgresql" ? "false" : "0"
+      get_uuid = "upgrade-033-get-#{SecureRandom.hex(4)}"
+      post_uuid = "upgrade-033-post-#{SecureRandom.hex(4)}"
+
+      @conn.execute(<<~SQL)
+        INSERT INTO rails_pulse_requests (route_id, duration, status, is_error, request_uuid, occurred_at, created_at, updated_at)
+        VALUES (#{get_id}, 10, 200, #{is_error_value}, '#{get_uuid}', '#{now}', '#{now}', '#{now}')
+      SQL
+      @conn.execute(<<~SQL)
+        INSERT INTO rails_pulse_requests (route_id, duration, status, is_error, request_uuid, occurred_at, created_at, updated_at)
+        VALUES (#{post_id}, 20, 201, #{is_error_value}, '#{post_uuid}', '#{now}', '#{now}', '#{now}')
+      SQL
+
+      run_all_migrations
+
+      rows = @conn.select_all("SELECT id, http_methods, controller_action FROM rails_pulse_routes WHERE path = '/users' ORDER BY id").to_a
+
+      assert_equal 2, rows.size, "GET /users and POST /users must remain two routes until migrate_routes backfills actions"
+      assert rows.all? { |row| row["controller_action"].nil? }
+
+      methods = rows.map { |row| JSON.parse(row["http_methods"]) }.sort
+
+      assert_equal [ [ "GET" ], [ "POST" ] ], methods
+      assert_equal "GET", @conn.select_value("SELECT method FROM rails_pulse_requests WHERE request_uuid = '#{get_uuid}'")
+      assert_equal "POST", @conn.select_value("SELECT method FROM rails_pulse_requests WHERE request_uuid = '#{post_uuid}'")
+    end
+
+    test "can insert records after upgrading from v0.3.3" do
+      load_baseline(RailsPulse::TestSchemas::V033)
+      run_all_migrations
+
+      assert_can_insert_core_records
+      assert_can_insert_deployment
+      assert_can_insert_exception
+      assert_can_insert_job_run
+    end
+
+    test "upgrade from v0.2.7 converts routes to multi-verb model" do
     load_baseline(RailsPulse::TestSchemas::V027)
     run_all_migrations
 
@@ -161,7 +239,16 @@ class UpgradeMigrationTest < ActiveSupport::TestCase
     assert RailsPulse::RouteIndexes.exists?(@conn)
   end
 
-  test "upgrade from v0.2.7 adds diagnostic columns to operations and requests" do
+    test "http_methods is NOT NULL after upgrading from v0.2.7" do
+      load_baseline(RailsPulse::TestSchemas::V027)
+      run_all_migrations
+
+      col = @conn.columns(:rails_pulse_routes).find { |c| c.name == "http_methods" }
+
+      assert_not col.null, "http_methods should be NOT NULL after upgrade"
+    end
+
+    test "upgrade from v0.2.7 adds diagnostic columns to operations and requests" do
     load_baseline(RailsPulse::TestSchemas::V027)
     run_all_migrations
 

--- a/test/support/generator_test_helpers.rb
+++ b/test/support/generator_test_helpers.rb
@@ -47,6 +47,20 @@ module GeneratorTestHelpers
     YAML
   end
 
+  def separate_database_yml_without_schema_dump
+    <<~YAML
+      development:
+        adapter: sqlite3
+        database: db/development.sqlite3
+
+      test:
+        rails_pulse:
+          adapter: sqlite3
+          database: db/test_rails_pulse.sqlite3
+          migrations_paths: db/rails_pulse_migrate
+    YAML
+  end
+
   def separate_database_yml
     <<~YAML
       development:

--- a/test/support/schemas/v0_3_3.rb
+++ b/test/support/schemas/v0_3_3.rb
@@ -1,0 +1,182 @@
+# Schema snapshot from v0.3.3 (current public gem).
+# Used by migration regression tests to simulate an upgrade from that release.
+# Has diagnostic fields, p95/p99, deployments, job_runs, and actual_sql.
+# Missing vs current: exception tables, controller_action / http_methods on routes,
+# method on requests, null-action unique index.
+module RailsPulse
+  module TestSchemas
+    V033 = lambda do |connection|
+      adapter = connection.adapter_name.downcase
+
+      unless connection.table_exists?(:rails_pulse_routes)
+        connection.create_table :rails_pulse_routes do |t|
+          t.string :method, null: false
+          t.string :path, null: false
+          t.text :tags
+          t.timestamps
+        end
+        connection.add_index :rails_pulse_routes, [ :method, :path ], unique: true, name: "index_rails_pulse_routes_on_method_and_path"
+        connection.add_index :rails_pulse_routes, :path, name: "index_rails_pulse_routes_on_path"
+      end
+
+      unless connection.table_exists?(:rails_pulse_queries)
+        connection.create_table :rails_pulse_queries do |t|
+          t.string :hashed_sql, limit: 32, null: false
+          t.text :normalized_sql, null: false
+          t.datetime :analyzed_at
+          t.text :explain_plan
+          t.text :issues
+          t.text :metadata
+          t.text :query_stats
+          t.text :backtrace_analysis
+          t.text :index_recommendations
+          t.text :n_plus_one_analysis
+          t.text :suggestions
+          t.text :tags
+          t.timestamps
+        end
+        connection.add_index :rails_pulse_queries, :hashed_sql, unique: true, name: "index_rails_pulse_queries_on_hashed_sql"
+      end
+
+      unless connection.table_exists?(:rails_pulse_requests)
+        connection.create_table :rails_pulse_requests do |t|
+          t.references :route, null: false, foreign_key: { to_table: :rails_pulse_routes }
+          t.decimal :duration, precision: 15, scale: 6, null: false
+          t.integer :status, null: false
+          t.boolean :is_error, null: false, default: false
+          t.string :request_uuid, null: false
+          t.string :controller_action
+          t.timestamp :occurred_at, null: false
+          t.text :tags
+          t.integer :response_size_bytes
+          t.timestamps
+        end
+        connection.add_index :rails_pulse_requests, :occurred_at, name: "index_rails_pulse_requests_on_occurred_at"
+        connection.add_index :rails_pulse_requests, :request_uuid, unique: true, name: "index_rails_pulse_requests_on_request_uuid"
+        connection.add_index :rails_pulse_requests, [ :route_id, :occurred_at ], name: "index_rails_pulse_requests_on_route_id_and_occurred_at"
+      end
+
+      unless connection.table_exists?(:rails_pulse_jobs)
+        connection.create_table :rails_pulse_jobs do |t|
+          t.string :name, null: false
+          t.string :queue_name
+          t.text :description
+          t.integer :runs_count, null: false, default: 0
+          t.integer :failures_count, null: false, default: 0
+          t.integer :retries_count, null: false, default: 0
+          t.decimal :avg_duration, precision: 15, scale: 6
+          t.decimal :p95_duration, precision: 15, scale: 6
+          t.decimal :p99_duration, precision: 15, scale: 6
+          t.text :tags
+          t.timestamps
+        end
+        connection.add_index :rails_pulse_jobs, :name, unique: true, name: "index_rails_pulse_jobs_on_name"
+        connection.add_index :rails_pulse_jobs, :queue_name, name: "index_rails_pulse_jobs_on_queue"
+        connection.add_index :rails_pulse_jobs, :runs_count, name: "index_rails_pulse_jobs_on_runs_count"
+      end
+
+      unless connection.table_exists?(:rails_pulse_job_runs)
+        connection.create_table :rails_pulse_job_runs do |t|
+          t.references :job, null: false, foreign_key: { to_table: :rails_pulse_jobs }
+          t.string :run_id, null: false
+          t.decimal :duration, precision: 15, scale: 6
+          t.string :status, null: false
+          t.string :error_class
+          t.text :error_message
+          t.integer :attempts, null: false, default: 0
+          t.timestamp :occurred_at, null: false
+          t.timestamp :enqueued_at
+          t.text :arguments
+          t.string :adapter
+          t.text :tags
+          t.timestamps
+        end
+        connection.add_index :rails_pulse_job_runs, :run_id, unique: true, name: "index_rails_pulse_job_runs_on_run_id"
+        connection.add_index :rails_pulse_job_runs, [ :job_id, :occurred_at ], name: "index_rails_pulse_job_runs_on_job_and_occurred"
+        connection.add_index :rails_pulse_job_runs, :occurred_at, name: "index_rails_pulse_job_runs_on_occurred_at"
+        connection.add_index :rails_pulse_job_runs, :status, name: "index_rails_pulse_job_runs_on_status"
+        connection.add_index :rails_pulse_job_runs, [ :job_id, :status ], name: "index_rails_pulse_job_runs_on_job_and_status"
+      end
+
+      unless connection.table_exists?(:rails_pulse_operations)
+        connection.create_table :rails_pulse_operations do |t|
+          t.references :request, null: true, foreign_key: { to_table: :rails_pulse_requests }
+          t.references :job_run, null: true, foreign_key: { to_table: :rails_pulse_job_runs }
+          t.references :query, foreign_key: { to_table: :rails_pulse_queries }, index: false
+          t.string :operation_type, null: false
+          t.string :label, null: false
+          t.decimal :duration, precision: 15, scale: 6, null: false
+          t.string :codebase_location
+          t.float :start_time, null: false, default: 0.0
+          t.timestamp :occurred_at, null: false
+          t.integer :row_count
+          t.boolean :cache_hit
+          t.text :actual_sql
+          t.text :repeated_query_group
+          t.integer :repetition_count
+          t.timestamps
+        end
+        connection.add_index :rails_pulse_operations, :operation_type, name: "index_rails_pulse_operations_on_operation_type"
+        connection.add_index :rails_pulse_operations, [ :query_id, :occurred_at ], name: "index_rails_pulse_operations_on_query_and_time"
+        connection.add_index :rails_pulse_operations, [ :query_id, :duration, :occurred_at ], name: "index_rails_pulse_operations_query_performance"
+        connection.add_index :rails_pulse_operations, [ :occurred_at, :duration, :operation_type ], name: "index_rails_pulse_operations_on_time_duration_type"
+
+        if adapter.include?("postgres") || adapter.include?("mysql")
+          connection.add_check_constraint :rails_pulse_operations,
+            "(request_id IS NOT NULL OR job_run_id IS NOT NULL)",
+            name: "rails_pulse_operations_request_or_job_run"
+        end
+      end
+
+      unless connection.table_exists?(:rails_pulse_summaries)
+        connection.create_table :rails_pulse_summaries do |t|
+          t.datetime :period_start, null: false
+          t.datetime :period_end, null: false
+          t.string :period_type, null: false
+          t.references :summarizable, polymorphic: true, null: false, index: true
+          t.integer :count, default: 0, null: false
+          t.float :avg_duration
+          t.float :min_duration
+          t.float :max_duration
+          t.float :p50_duration
+          t.float :p95_duration
+          t.float :p99_duration
+          t.float :total_duration
+          t.float :stddev_duration
+          t.integer :error_count, default: 0
+          t.integer :success_count, default: 0
+          t.integer :status_2xx, default: 0
+          t.integer :status_3xx, default: 0
+          t.integer :status_4xx, default: 0
+          t.integer :status_5xx, default: 0
+          t.timestamps
+        end
+        connection.add_index :rails_pulse_summaries, [ :summarizable_type, :summarizable_id, :period_type, :period_start ], unique: true, name: "idx_pulse_summaries_unique"
+        connection.add_index :rails_pulse_summaries, [ :period_type, :period_start ], name: "index_rails_pulse_summaries_on_period"
+        connection.add_index :rails_pulse_summaries, :created_at, name: "index_rails_pulse_summaries_on_created_at"
+        connection.add_index :rails_pulse_summaries, :summarizable_id, name: "index_rails_pulse_summaries_on_summarizable_id"
+        connection.add_index :rails_pulse_summaries, :period_start, name: "index_rails_pulse_summaries_on_period_start"
+      end
+
+      unless connection.table_exists?(:rails_pulse_deployments)
+        connection.create_table :rails_pulse_deployments do |t|
+          t.string   :revision,    null: false
+          t.datetime :started_at,  null: false
+          t.datetime :finished_at
+          t.text     :metadata
+          t.timestamps
+        end
+        connection.add_index :rails_pulse_deployments, :started_at, name: "index_rails_pulse_deployments_on_started_at"
+        connection.add_index :rails_pulse_deployments, :revision, name: "index_rails_pulse_deployments_on_revision"
+      end
+
+      unless connection.index_exists?(:rails_pulse_requests, [ :created_at, :route_id ], name: "idx_requests_for_aggregation")
+        connection.add_index :rails_pulse_requests, [ :created_at, :route_id ], name: "idx_requests_for_aggregation"
+      end
+
+      unless connection.index_exists?(:rails_pulse_operations, [ :created_at, :query_id ], name: "idx_operations_for_aggregation")
+        connection.add_index :rails_pulse_operations, [ :created_at, :query_id ], name: "idx_operations_for_aggregation"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Makes the 0.3.3 → current upgrade safe for existing hosts: exception capture stays off until they opt in, the upgrade generator appends new initializer settings for `git diff` review, and the docs spell out `migrate_routes` plus a full-process restart.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)
- [x] Documentation update
- [x] Test improvements
- [ ] Build/CI improvements

## Changes Made

- Default `track_exceptions` to `false`. Existing 0.3.3 initializers omit the key; a `true` default would start storing unfiltered exception messages on gem bump. New apps still get `true` from the install template.
- Upgrade generator appends missing initializer keys (and `max_table_records` entries) inside `RailsPulse.configure` without rewriting host values. `track_exceptions` is inserted as `false`. Insertion targets the configure block, not the last `end` in the file (hosts may have a trailing `to_prepare` block).
- `CleanupService` skips exception tables until they exist, so `CleanupJob` does not crash between gem bump and migrate.
- Multi-verb route migration sets `http_methods` NOT NULL after backfill.
- README / CHANGELOG / database setup / releasing docs: upgrade steps, separate-DB `db:migrate:rails_pulse`, deploy order (no mixed 0.3.3 + new processes against the new schema).
- v0.3.3 schema snapshot and generator/updater tests for the upgrade path.

### Test Results

- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Manual testing completed
- [x] Tested across multiple databases (SQLite, PostgreSQL, MySQL)
- [ ] Tested across multiple Rails versions (7.2, 8.0, 8.1)

## Breaking Changes

- [ ] No breaking changes
- [x] Breaking changes documented below

Route identity (`method` off the route, onto each request) is already on `main`. This PR does not add that schema change; it documents how to upgrade through it and keeps exception tracking off until hosts opt in.

```
bundle update rails_pulse
rails generate rails_pulse:upgrade
rails db:migrate                  # or: rails db:migrate:rails_pulse
rails rails_pulse:migrate_routes  # required once
```

Restart **all** processes after migrate. Then set `config.track_exceptions = true` to opt in.

## Screenshots

N/A

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)
- [x] No new warnings or errors introduced
- [x] Tests added/updated and passing
- [x] Changes work with all supported databases
- [ ] Changes work with all supported Rails versions
- [ ] Asset changes compiled and included (if applicable)

## Additional Notes

Manual matrix: `tmp/upgrade_scenarios/run all` on SQLite, PostgreSQL, and MySQL. Path-gem upgrade against Eureka: generator + initializer sync + `db:migrate`. `migrate_routes` and a dashboard pass on a real host are still worth doing before release.

Start review at `lib/rails_pulse/installers/config_updater.rb` and `lib/generators/rails_pulse/upgrade_generator.rb`.